### PR TITLE
Upgrade CI for latest GeoServer versions

### DIFF
--- a/.github/workflows/ci-geoserver-node-client.yml
+++ b/.github/workflows/ci-geoserver-node-client.yml
@@ -10,7 +10,7 @@ jobs:
   run-tests-maintenance:
     runs-on: ubuntu-latest
     env:
-      GEOSERVER_VERSION: 2.17.5
+      GEOSERVER_VERSION: 2.18.2
     steps:
       - uses: actions/checkout@v2
 
@@ -33,7 +33,7 @@ jobs:
   run-tests-stable:
     runs-on: ubuntu-latest
     env:
-      GEOSERVER_VERSION: 2.18.2
+      GEOSERVER_VERSION: 2.19.0
     steps:
       - uses: actions/checkout@v2
 


### PR DESCRIPTION
Upgrades the CI jobs for latest GeoServer versions:

  - Maintenance: 2.18.2
  - Stable: 2.19.0