### PR TITLE
Fix setting proxyBaseUrl

### DIFF
--- a/src/settings.js
+++ b/src/settings.js
@@ -74,13 +74,15 @@ export default class SettingsClient {
    * @returns {Boolean} Flag indicating if request was successful
    */
   async updateProxyBaseUrl (proxyBaseUrl) {
-    const settingsJson = {
-      global: {
-        settings: {
-          proxyBaseUrl: proxyBaseUrl
-        }
-      }
-    };
+    const settingsJson = await this.getSettings();
+
+    if (!settingsJson.global && !settingsJson.global.settings) {
+      // settings seem to be wrongly formated
+      return false;
+    }
+
+    // add proxyBaseUrl to settings
+    settingsJson.global.settings.proxyBaseUrl = proxyBaseUrl;
 
     return await this.updateSettings(settingsJson);
   }


### PR DESCRIPTION
Before the baseUrl was set, but the sideeffect was that other properties were reset to default. 

Now, the original settings object is modified. And the other properties are untouched.

This caused a corrupt Capabilities file and probably causes other problems as well.