### PR TITLE
Add function 'get' to WorkspaceClient

### DIFF
--- a/src/workspace.js
+++ b/src/workspace.js
@@ -43,6 +43,33 @@ export default class WorkspaceClient {
   }
 
   /**
+   * Returns a workspace.
+   *
+   * @param {String} name Name of the workspace
+   * @returns {Object|Boolean} An object describing the workspaces or 'false'
+   */
+  async get (name) {
+    try {
+      const auth =
+        Buffer.from(this.user + ':' + this.password).toString('base64');
+      const response = await fetch(this.url + 'workspaces/' + name + '.json', {
+        credentials: 'include',
+        method: 'GET',
+        headers: {
+          Authorization: 'Basic ' + auth
+        }
+      });
+      if (response.status === 200) {
+        return await response.json();
+      } else {
+        return false;
+      }
+    } catch (error) {
+      return false;
+    }
+  }
+
+  /**
    * Creates a new workspace.
    *
    * @param {String} name Name of the new workspace

--- a/test/test.js
+++ b/test/test.js
@@ -109,6 +109,11 @@ describe('Workspace', () => {
     expect(gsWorkspaces.workspaces.workspace[0].name).to.equal(workSpace);
   });
 
+  it('query dedicated workspace', async () => {
+    const gsWorkspace = await grc.workspaces.get(workSpace);
+    expect(gsWorkspace.workspace.name).to.equal(workSpace);
+  });
+
   it('delete workspace', async () => {
     const recursive = true;
     const result = await grc.workspaces.delete(workSpace, recursive);


### PR DESCRIPTION
Adds a function `get` to the `WorkspaceClient` in order to query a dedicated workspace:

`const gsWorkspace = await grc.workspaces.get('my-ws');`