### PR TITLE
Add 'nativeBoundingBox' to LayerClient.publishFeatureType

### DIFF
--- a/demo/index.js
+++ b/demo/index.js
@@ -98,6 +98,19 @@ grc.getVersion().then(versionInfo => {
 // grc.layers.publishFeatureType(ws, 'testdataStore', 'nativeFtName', 'aTestName2', 'Test Title 2', 'EPSG:31468', true).then(retVal => {
 //   console.log('Created Layer', prettyJson(retVal));
 // });
+// const nativeBoundingBox = {
+//   minx: 8.15,
+//   maxx: 8.16,
+//   miny: 50.0,
+//   maxy: 50.1,
+//   crs: {
+//     '@class': 'projected',
+//     $: 'EPSG:4326'
+//   }
+// };
+// grc.layers.publishFeatureType(ws, 'testdataStore', 'nativeFtName', 'aTestNameBbox', 'Test Title Bbox', 'EPSG:4326', true, null, nativeBoundingBox).then(retVal => {
+//   console.log('Created FT with explicit native BBOX', prettyJson(retVal));
+// });
 // grc.layers.publishWmsLayer(ws, 'testWmsDs', 'OSM-Overlay-WMS', 'aTestName4Wms', 'Test Title WMS', 'EPSG:900913', true).then(retVal => {
 //   console.log('Created WMS Layer', prettyJson(retVal));
 // });

--- a/src/layer.js
+++ b/src/layer.js
@@ -181,11 +181,20 @@ export default class LayerClient {
    * @param {String} [srs="EPSG:4326"] The SRS of the FeatureType
    * @param {String} enabled Flag to enable FeatureType by default
    * @param {String} [abstract] The abstract of the layer
+   * @param {String} [nativeBoundingBox] The native BoundingBox of the FeatureType (has to be set if no data is in store at creation time)
    *
    * @returns {Boolean} If the FeatureType could be published
    */
-  async publishFeatureType (workspace, dataStore, nativeName, name, title, srs, enabled, abstract) {
+  async publishFeatureType (workspace, dataStore, nativeName, name, title, srs, enabled, abstract, nativeBoundingBox) {
     try {
+      // apply CRS info for native BBOX if not provided
+      if (nativeBoundingBox && !nativeBoundingBox.crs) {
+        nativeBoundingBox.crs = {
+          '@class': 'projected',
+          $: srs
+        }
+      }
+
       const body = {
         featureType: {
           name: name || nativeName,
@@ -193,7 +202,8 @@ export default class LayerClient {
           title: title || name,
           srs: srs || 'EPSG:4326',
           enabled: enabled,
-          abstract: abstract || ''
+          abstract: abstract || '',
+          nativeBoundingBox: nativeBoundingBox
         }
       };
 

--- a/test/test.js
+++ b/test/test.js
@@ -234,6 +234,29 @@ describe('Layer', () => {
     expect(result).to.be.true;
   });
 
+  it('can publish a FeatureType with explicit native BBOX', async () => {
+    const ftName = featureLayerName + '_native_bbox';
+    const nativeBoundingBox = {
+      minx: 8.15,
+      maxx: 8.16,
+      miny: 50.0,
+      maxy: 50.1
+    };
+
+    const result = await grc.layers.publishFeatureType(
+      workSpace,
+      wfsDataStore,
+      'osm_osm-country-borders',
+      ftName,
+      'My Feature title native BBOX',
+      'EPSG:4326',
+      true,
+      'Sample Abstract native BBOX',
+      nativeBoundingBox
+    );
+    expect(result).to.be.true;
+  });
+
   it('can publish a WMS layer', async () => {
     // TODO: make sure WMS url is still working
     const wmsUrl = 'https://ows.terrestris.de/osm/service?';
@@ -272,7 +295,7 @@ describe('Layer', () => {
 
   it('can get retrieve all layers', async () => {
     const result = await grc.layers.getAll();
-    expect(result.layers.layer.length).to.equal(2);
+    expect(result.layers.layer.length).to.equal(3);
   })
 
   it('can get a layer by qualified name', async () => {


### PR DESCRIPTION
This adds the optional parameter `nativeBoundingBox` to the function `LayerClient.publishFeatureType`.
Has to be set if no data is in store at FeatureType creation time, otherwise it will fail.

Fixes #23