### PR TITLE
Add `namespace` endpoint

### DIFF
--- a/demo/index.js
+++ b/demo/index.js
@@ -18,6 +18,23 @@ grc.getVersion().then(versionInfo => {
   console.log('GeoServer REST version info', prettyJson(versionInfo));
 });
 
+// NAMESPACES
+
+// const nsPrefix = 'example-namespace';
+// const nsUri = 'http://www.example.com'
+// grc.namespaces.create(nsPrefix, nsUri).then(retVal => {
+//   console.log('Created GeoServer NS', prettyJson(retVal));
+// });
+// grc.namespaces.getAll().then(gsWorkspaces => {
+//   console.log('GeoServer All NS', prettyJson(gsWorkspaces));
+// });
+// grc.namespaces.get(nsPrefix).then(gsWorkspaces => {
+//   console.log('GeoServer NS', prettyJson(gsWorkspaces));
+// });
+// grc.namespaces.delete(nsPrefix).then(gsWorkspaces => {
+//   console.log('Deleted GeoServer NS', prettyJson(gsWorkspaces));
+// });
+
 // WORKSPACES
 
 // grc.workspaces.getAll().then(gsWorkspaces => {

--- a/demo/index.js
+++ b/demo/index.js
@@ -25,14 +25,14 @@ grc.getVersion().then(versionInfo => {
 // grc.namespaces.create(nsPrefix, nsUri).then(retVal => {
 //   console.log('Created GeoServer NS', prettyJson(retVal));
 // });
-// grc.namespaces.getAll().then(gsWorkspaces => {
-//   console.log('GeoServer All NS', prettyJson(gsWorkspaces));
+// grc.namespaces.getAll().then(gsNamespaces => {
+//   console.log('GeoServer All NS', prettyJson(gsNamespaces));
 // });
-// grc.namespaces.get(nsPrefix).then(gsWorkspaces => {
-//   console.log('GeoServer NS', prettyJson(gsWorkspaces));
+// grc.namespaces.get(nsPrefix).then(gsNamespaces => {
+//   console.log('GeoServer NS', prettyJson(gsNamespaces));
 // });
-// grc.namespaces.delete(nsPrefix).then(gsWorkspaces => {
-//   console.log('Deleted GeoServer NS', prettyJson(gsWorkspaces));
+// grc.namespaces.delete(nsPrefix).then(gsNamespaces => {
+//   console.log('Deleted GeoServer NS', prettyJson(gsNamespaces));
 // });
 
 // WORKSPACES

--- a/geoserver-rest-client.js
+++ b/geoserver-rest-client.js
@@ -6,6 +6,7 @@ import DatastoreClient from './src/datastore.js';
 import ImageMosaicClient from './src/imagemosaic.js';
 import SecurityClient from './src/security.js';
 import SettingsClient from './src/settings.js';
+import NamespaceClient from './src/namespace.js';
 
 /**
  * Client for GeoServer REST API.
@@ -33,6 +34,8 @@ export default class GeoServerRestClient {
     this.styles = new StyleClient(this.url, this.user, this.password);
     /** @member {WorkspaceClient} workspaces GeoServer REST client instance for workspaces */
     this.workspaces = new WorkspaceClient(this.url, this.user, this.password);
+    /** @member {NamespaceClient} namespaces GeoServer REST client instance for namespaces */
+    this.namespaces = new NamespaceClient(this.url, this.user, this.password);
     /** @member {DatastoreClient} datastores GeoServer REST client instance for data stores */
     this.datastores = new DatastoreClient(this.url, this.user, this.password);
     /** @member {ImageMosaicClient} imagemosaics GeoServer REST client instance for image mosaics */
@@ -45,7 +48,7 @@ export default class GeoServerRestClient {
 
   /**
    * Get the GeoServer version.
-   * 
+   *
    * @returns {String|Boolean} The version of GeoServer or 'false'
    */
   async getVersion () {
@@ -67,7 +70,7 @@ export default class GeoServerRestClient {
 
   /**
    * Checks if the configured GeoServer REST connection exists.
-   * 
+   *
    * @returns {Boolean} If the connection exists
    */
   async exists () {

--- a/src/datastore.js
+++ b/src/datastore.js
@@ -228,6 +228,7 @@ s  */
    * Creates a PostGIS based data store.
    *
    * @param {String} workspace The WS to create the data store in
+   * @param {String} namespaceUri The namespace URI of the workspace
    * @param {String} dataStore The data store name to be created
    * @param {String} pgHost The PostGIS DB host
    * @param {String} pgPort The PostGIS DB port
@@ -239,12 +240,15 @@ s  */
    *
    * @returns {Boolean} If the store could be created
    */
-  async createPostgisStore (workspace, dataStore, pgHost, pgPort, pgUser, pgPassword, pgSchema, pgDb, exposePk) {
+  async createPostgisStore (workspace, namespaceUri, dataStore, pgHost, pgPort, pgUser, pgPassword, pgSchema, pgDb, exposePk) {
     const body = {
       dataStore: {
         name: dataStore,
         type: 'PostGIS',
         enabled: true,
+        workspace: {
+          name: workspace
+        },
         connectionParameters: {
           entry: [
             {
@@ -273,7 +277,7 @@ s  */
             },
             {
               '@key': 'namespace',
-              $: workspace
+              $: namespaceUri
             },
             {
               '@key': 'user',

--- a/src/namespace.js
+++ b/src/namespace.js
@@ -1,0 +1,142 @@
+import fetch from 'node-fetch';
+
+/**
+ * Client for GeoServer namespace
+ *
+ * @module NamespaceClient
+ */
+export default class NamespaceClient {
+  /**
+   * Creates a GeoServer REST NamespaceClient instance.
+   *
+   * @param {String} url The URL of the GeoServer REST API endpoint
+   * @param {String} user The user for the GeoServer REST API
+   * @param {String} password The password for the GeoServer REST API
+   */
+  constructor (url, user, password) {
+    this.url = url.endsWith('/') ? url : url + '/';
+    this.user = user;
+    this.password = password;
+  }
+
+  /**
+   * Returns all namespaces.
+   *
+   * @returns {Object|Boolean} An object describing the namespace or 'false'
+   */
+  async getAll () {
+    try {
+      const auth =
+        Buffer.from(this.user + ':' + this.password).toString('base64');
+      const response = await fetch(this.url + 'namespaces.json', {
+        credentials: 'include',
+        method: 'GET',
+        headers: {
+          Authorization: 'Basic ' + auth
+        }
+      });
+      const json = await response.json();
+      return json;
+    } catch (error) {
+      return false;
+    }
+  }
+
+  /**
+   * Creates a new namespace.
+   *
+   * @param {String} prefix Prefix of the new namespace
+   * @param {String} uri Uri of the new namespace
+   *
+   * @returns {String|Boolean} The name of the created namespace or 'false'
+   */
+  async create (prefix, uri) {
+    try {
+      const body = {
+        namespace: {
+          prefix: prefix,
+          uri: uri
+        }
+      };
+
+      const auth =
+        Buffer.from(this.user + ':' + this.password).toString('base64');
+
+      const response = await fetch(this.url + 'namespaces', {
+        credentials: 'include',
+        method: 'POST',
+        headers: {
+          Authorization: 'Basic ' + auth,
+          'Content-Type': 'application/json'
+        },
+        body: JSON.stringify(body)
+      });
+
+      if (response.status === 201) {
+        const responseText = await response.text();
+        return responseText;
+      } else {
+        return false;
+      }
+    } catch (error) {
+      return false;
+    }
+  }
+
+  /**
+   * Returns a namespace.
+   *
+   * @param {String} name Name of the namespace
+   * @returns {Object|Boolean} An object describing the namespace or 'false'
+   */
+  async get (name) {
+    try {
+      const auth =
+        Buffer.from(this.user + ':' + this.password).toString('base64');
+      const response = await fetch(this.url + 'namespaces/' + name + '.json', {
+        credentials: 'include',
+        method: 'GET',
+        headers: {
+          Authorization: 'Basic ' + auth
+        }
+      });
+      if (response.status === 200) {
+        return await response.json();
+      } else {
+        return false;
+      }
+    } catch (error) {
+      return false;
+    }
+  }
+
+  /**
+   * Deletes a namespace.
+   *
+   * @param {String} name Name of the namespace to delete
+   *
+   * @returns {Boolean} If deletion was successful
+   */
+  async delete (name) {
+    try {
+      const auth =
+        Buffer.from(this.user + ':' + this.password).toString('base64');
+      const response = await fetch(this.url + 'namespaces/' + name, {
+        credentials: 'include',
+        method: 'DELETE',
+        headers: {
+          Authorization: 'Basic ' + auth
+        }
+      });
+
+      // TODO map other HTTP status
+      if (response.status === 200) {
+        return true;
+      } else {
+        return false;
+      }
+    } catch (error) {
+      return false;
+    }
+  }
+}

--- a/test/test.js
+++ b/test/test.js
@@ -9,6 +9,10 @@ const pw = 'geoserver';
 const grc = new GeoServerRestClient(url, user, pw);
 
 const workSpace = 'my-workspace';
+
+const nameSpace = 'my-namespace';
+const nameSpaceUri = 'http://www.example.com';
+
 const geoServerVersion = process.env.GEOSERVER_VERSION;
 
 describe('Basic GeoServer', () => {
@@ -123,6 +127,40 @@ describe('Workspace', () => {
   it('has no workspace', async () => {
     const gsWorkspaces = await grc.workspaces.getAll();
     expect(gsWorkspaces.workspaces).to.equal('');
+  });
+});
+
+describe('Namespace', () => {
+  it('has no namespaces', async () => {
+    const gsNamespaces = await grc.namespaces.getAll();
+    expect(gsNamespaces.namespaces).to.equal('');
+  });
+
+  it('creates one namespace', async () => {
+    const result = await grc.namespaces.create(nameSpace, nameSpaceUri);
+    expect(result).to.equal(nameSpace);
+  });
+
+  it('has one namespace', async () => {
+    const gsNameSpaces = await grc.namespaces.getAll();
+    expect(gsNameSpaces.namespaces.namespace.length).to.equal(1);
+    expect(gsNameSpaces.namespaces.namespace[0].name).to.equal(nameSpace);
+  });
+
+  it('query dedicated namespace', async () => {
+    const gsNameSpace = await grc.namespaces.get(nameSpace);
+    expect(gsNameSpace.namespace.prefix).to.equal(nameSpace);
+    expect(gsNameSpace.namespace.uri).to.equal(nameSpaceUri);
+  });
+
+  it('delete namespace', async () => {
+    const result = await grc.namespaces.delete(nameSpace);
+    expect(result).to.be.true;
+  });
+
+  it('has no namespace', async () => {
+    const gsNameSpaces = await grc.namespaces.getAll();
+    expect(gsNameSpaces.namespaces).to.equal('');
   });
 });
 


### PR DESCRIPTION
- Adds a `namespace` endpoint. It can be used instead of the `workspace` endpoint.  Even though it is called "namespace" it also creates a "workspace" with the difference that it also adds a `uri`. This is crucial for the PostGIS datastore. See #31 
-  Adds the parameter `namespaceUri` to `createPostgisStore()` function. This seems necessary to make the PostGIS store initially work after creation. **WARNING** The parameter `namespaceUri` is now mandatory and at the second position. This means that upgrading an existing script needs (minor) adjustment.


