### PR TITLE
Add option useHttpConnectionPooling for WFS store

### DIFF
--- a/demo/index.js
+++ b/demo/index.js
@@ -87,9 +87,9 @@ grc.getVersion().then(versionInfo => {
 // grc.datastores.createWmsStore(ws, 'testWmsDs', wmsUrl).then(retVal => {
 //   console.log('Created WMS data store', prettyJson(retVal));
 // });
-// const wfsCapsUrl = 'https://ows.terrestris.de/geoserver/osm/wfs?service=wfs&version=1.1.0&request=GetCapabilities';
+// const wfsCapsUrl = 'https://services.meggsimum.de/geoserver/ows?service=wfs&version=1.1.0&request=GetCapabilities';
 // const namespaceUrl = 'http://test';
-// grc.datastores.createWfsStore(ws, 'testWfsDs', wfsCapsUrl, namespaceUrl).then(retVal => {
+// grc.datastores.createWfsStore(ws, 'testWfsDs', wfsCapsUrl, namespaceUrl, false).then(retVal => {
 //   console.log('Created WFS data store', prettyJson(retVal));
 // });
 // grc.datastores.deleteDataStore(ws, 'testWfsDs', false).then(gsWmsStores => {

--- a/src/datastore.js
+++ b/src/datastore.js
@@ -404,7 +404,7 @@ s  */
    *
    * @returns {Boolean} If store could be created
    */
-  async createWfsStore (workspace, dataStore, wfsCapabilitiesUrl, namespaceUrl) {
+  async createWfsStore (workspace, dataStore, wfsCapabilitiesUrl, namespaceUrl, useHttpConnectionPooling) {
     const body = {
       dataStore: {
         name: dataStore,
@@ -418,6 +418,10 @@ s  */
             {
               '@key': 'namespace',
               $: namespaceUrl
+            },
+            {
+              '@key': 'WFSDataStoreFactory:USE_HTTP_CONNECTION_POOLING',
+              $: useHttpConnectionPooling !== false ? 'true' : 'false'
             }
           ]
         }


### PR DESCRIPTION
This adds the optional parameter `useHttpConnectionPooling` to the function `createWfsStore` in the `DatastoreClient`.
By setting this parameter to `false` the HTTP connection pooling can be disabled. Otherwise HTTP connection pooling is enabled by default.