### PR TITLE
Add API docs for useHttpConnectionPooling

### DIFF
--- a/src/datastore.js
+++ b/src/datastore.js
@@ -401,6 +401,7 @@ s  */
    * @param {String} dataStore The data store name
    * @param {String} wfsCapabilitiesUrl WFS capabilities URL
    * @param {String} namespaceUrl URL of the GeoServer namespace
+   * @param {Boolean} [useHttpConnectionPooling=true] use HTTP connection pooling for WFS connection
    *
    * @returns {Boolean} If store could be created
    */


### PR DESCRIPTION
This adds the API docs for new `useHttpConnectionPooling` parameter in `createWfsStore`. Follow up for PR #38.