### PR TITLE
README: describe environement variable for running tests locally

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,10 @@ docker run \
 Then, in an other terminal, run:
 
 ```shell
+# the GeoServer version the tests should verfiy
+export GEOSERVER_VERSION=2.20.1
+
+# run the test suite
 npm run test
 ```
 

--- a/README.md
+++ b/README.md
@@ -49,11 +49,8 @@ docker run \
 Then, in an other terminal, run:
 
 ```shell
-# the GeoServer version the tests should verfiy
-export GEOSERVER_VERSION=2.20.1
-
-# run the test suite
-npm run test
+# specify the GeoServer version and run the test suite
+GEOSERVER_VERSION=2.20.1 npm run test
 ```
 
 ### Release


### PR DESCRIPTION
The test suite checks if the GeoServer version is read correctly. The value has to be provided via an environment variable. This is done in the CI automatically. But for running the tests locally it is necessary to set it manually.

```shell
export GEOSERVER_VERSION=2.20.1
```