### PR TITLE
Swap arguments in `getStyleInformation`

### DIFF
--- a/src/style.js
+++ b/src/style.js
@@ -199,7 +199,7 @@ export default class StyleClient {
    * @throws Error if request fails
    */
   async assignStyleToLayer (qualifiedName, styleName, workspaceStyle, isDefaultStyle) {
-    const styleBody = await this.getStyleInformation(styleName, workspaceStyle);
+    const styleBody = await this.getStyleInformation(workspaceStyle, styleName);
 
     const response = await fetch(this.url + 'layers/' + qualifiedName + '/styles?default=' + isDefaultStyle, {
       credentials: 'include',
@@ -220,14 +220,14 @@ export default class StyleClient {
   /**
    * Get information about a style.
    *
+   * @param {String} workspace The name of the workspace, can be undefinded
    * @param {String} styleName The name of the style
-   * @param {String} [workspace] The name of the workspace
    *
    * @throws Error if request fails
    *
    * @returns {Object} An object about the style or undefined if it cannot be found
    */
-  async getStyleInformation (styleName, workspace) {
+  async getStyleInformation (workspace, styleName) {
     let url;
     if (workspace) {
       url = this.url + 'workspaces/' + workspace + '/styles/' + styleName + '.json';

--- a/src/style.js
+++ b/src/style.js
@@ -206,7 +206,7 @@ export default class StyleClient {
     } else {
       qualifiedName = layerName;
     }
-    const styleBody = await this.getStyleInformation(styleName, workspaceOfStyle);
+    const styleBody = await this.getStyleInformation(workspaceOfStyle, styleName);
 
     const response = await fetch(this.url + 'layers/' + qualifiedName + '/styles?default=' + isDefaultStyle, {
       credentials: 'include',

--- a/src/style.js
+++ b/src/style.js
@@ -193,13 +193,13 @@ export default class StyleClient {
    *
    * @param {String} qualifiedName GeoServer layer name with workspace prefix
    * @param {String} styleName The name of the style
-   * @param {String} [workspaceStyle] The workspace of the style
+   * @param {String} [workspace] The workspace of the style
    * @param {Boolean} [isDefaultStyle=true] If the style should be the default style of the layer
    *
    * @throws Error if request fails
    */
-  async assignStyleToLayer (qualifiedName, styleName, workspaceStyle, isDefaultStyle) {
-    const styleBody = await this.getStyleInformation(workspaceStyle, styleName);
+  async assignStyleToLayer (qualifiedName, styleName, workspace, isDefaultStyle) {
+    const styleBody = await this.getStyleInformation(workspace, styleName);
 
     const response = await fetch(this.url + 'layers/' + qualifiedName + '/styles?default=' + isDefaultStyle, {
       credentials: 'include',

--- a/test/test.js
+++ b/test/test.js
@@ -438,10 +438,10 @@ describe('style', () => {
   });
 
   it('can get style information', async () => {
-    const result = await grc.styles.getStyleInformation(styleName, workSpace);
+    const result = await grc.styles.getStyleInformation(workSpace, styleName);
     expect(result.style.name).to.equal(styleName);
     expect(
-      await grc.styles.getStyleInformation('fantasyStlye', workSpace)
+      await grc.styles.getStyleInformation(workSpace, 'fantasyStyle')
     ).to.be.undefined;
   })
 


### PR DESCRIPTION
- based on PR #51 
- references partly #47 
- swaps the order of arguments in `getStyleInformation` from `(styleName, workSpace)` to `(workSpace, styleName)`
- the changes can be seen [HERE](https://github.com/JakobMiksch/geoserver-node-client/compare/auth-refactor...JakobMiksch:args-order)