### PR TITLE
Update README and docs landing page

### DIFF
--- a/DOCS_HOME.md
+++ b/DOCS_HOME.md
@@ -2,8 +2,6 @@
 
 Node.js / JavaScript Client for the [GeoServer REST API](https://docs.geoserver.org/stable/en/user/rest/).
 
-**CAUTION: This is highly bleeding edge, heavily under development and therefore breaking changes can be made at every time!**
-
 ### Meta information
 
 Compatible with [GeoServer](https://geoserver.org)
@@ -19,8 +17,9 @@ Compatible with [GeoServer](https://geoserver.org)
 
 ### Credits
 
-This project was initiated by [meggsimum](https://meggsimum.de) within the [mFund](https://www.bmvi.de/EN/Topics/Digital-Matters/mFund/mFund.html) research project [SAUBER](https://sauber-projekt.de/).
+This project was initiated by [meggsimum](https://meggsimum.de) within the [mFund](https://www.bmvi.de/EN/Topics/Digital-Matters/mFund/mFund.html) research project [SAUBER](https://sauber-projekt.de/) and is further developed in the mFund research project [KLIPS](http://www.klips-projekt.de/):
 <p><img src="https://sauber-projekt.de/wp-content/uploads/2018/12/SAG_SAUBER_Logo_Dez3_transparent-1-e1543843688935.png" alt="SAUBER Logo" width="200"/></p>.
+<p><img src="http://www.klips-projekt.de/wp-content/uploads/2021/02/SAG_KLIPS-Logo_Jan21.png" alt="KLIPS Logo" width="200"/></p>.
 
 <img src="https://sauber-projekt.de/wp-content/uploads/2018/12/mfund-logo-download-e1547545420815-300x77.jpg" alt="mFund Logo" width="300"/>
 <img src="https://sauber-projekt.de/wp-content/uploads/2019/06/BMVI_Fz_2017_Office_Farbe_de_Bundestag-400x402.png" alt="BMVI Logo" height="200"/>

--- a/README.md
+++ b/README.md
@@ -5,11 +5,9 @@
 
 Node.js / JavaScript Client for the [GeoServer REST API](https://docs.geoserver.org/stable/en/user/rest/).
 
-**CAUTION: This is highly bleeding edge, heavily under development and therefore breaking changes can be made at every time!**
-
 ### API-Docs ###
 
-Detailed API-Docs can be found [here](https://meggsimum.github.io/geoserver-node-client/index.html).
+Detailed [API-Docs](https://meggsimum.github.io/geoserver-node-client/) are automatically created with JSDoc.
 
 ### Meta information
 
@@ -59,14 +57,14 @@ First start a GeoServer, e.g. by using this Docker container:
 docker run \
   -p 8080:8080 \
   -v /path/to/geoserver_mnt:/opt/geoserver_data \
-  meggsimum/geoserver:2.20.1
+  meggsimum/geoserver:2.20.4
 ```
 
 Then, in an other terminal, run:
 
 ```shell
 # specify the GeoServer version and run the test suite
-GEOSERVER_VERSION=2.20.1 npm run test
+GEOSERVER_VERSION=2.20.4 npm run test
 ```
 
 ### Release
@@ -107,8 +105,9 @@ npm run release
 
 ### Credits
 
-This project was initiated by [meggsimum](https://meggsimum.de) within the [mFund](https://www.bmvi.de/EN/Topics/Digital-Matters/mFund/mFund.html) research project [SAUBER](https://sauber-projekt.de/).
+This project was initiated by [meggsimum](https://meggsimum.de) within the [mFund](https://www.bmvi.de/EN/Topics/Digital-Matters/mFund/mFund.html) research project [SAUBER](https://sauber-projekt.de/) and is further developed in the mFund research project [KLIPS](http://www.klips-projekt.de/):
 <p><img src="https://sauber-projekt.de/wp-content/uploads/2018/12/SAG_SAUBER_Logo_Dez3_transparent-1-e1543843688935.png" alt="SAUBER Logo" width="200"/></p>.
+<p><img src="http://www.klips-projekt.de/wp-content/uploads/2021/02/SAG_KLIPS-Logo_Jan21.png" alt="KLIPS Logo" width="200"/></p>.
 
 <img src="https://sauber-projekt.de/wp-content/uploads/2018/12/mfund-logo-download-e1547545420815-300x77.jpg" alt="mFund Logo" width="300"/>
 <img src="https://sauber-projekt.de/wp-content/uploads/2019/06/BMVI_Fz_2017_Office_Farbe_de_Bundestag-400x402.png" alt="BMVI Logo" height="200"/>


### PR DESCRIPTION
Minor update of README and docs landing page:

- remove note about "bleeding edge" status
- make link to docs more prominent
- add KLIPS as research project
- update GeoServer version in example snippet