### PR TITLE
Fix assign style

### DIFF
--- a/src/style.js
+++ b/src/style.js
@@ -200,9 +200,6 @@ export default class StyleClient {
    * @throws Error if request fails
    */
   async assignStyleToLayer (workspaceOfLayer, layerName, styleName, workspaceOfStyle, isDefaultStyle) {
-    // TODO: add default value
-    // TODO: ensure default value is true or false
-    // TODO: consider removing `?default` if no value provided
 
     let qualifiedName;
     if (workspaceOfLayer) {
@@ -212,7 +209,15 @@ export default class StyleClient {
     }
     const styleBody = await this.getStyleInformation(workspaceOfStyle, styleName);
 
-    const response = await fetch(this.url + 'layers/' + qualifiedName + '/styles?default=' + isDefaultStyle, {
+    let url;
+    // we set the style as defaultStyle, unless user explicitly provides 'false'
+    if (isDefaultStyle !== false) {
+      url = this.url + 'layers/' + qualifiedName + '/styles?default=true';
+    } else {
+      url = this.url + 'layers/' + qualifiedName + '/styles';
+    }
+
+    const response = await fetch(url, {
       credentials: 'include',
       method: 'POST',
       headers: {

--- a/src/style.js
+++ b/src/style.js
@@ -193,13 +193,13 @@ export default class StyleClient {
    *
    * @param {String} workspaceOfLayer The name of the layer's workspace, can be undefined
    * @param {String} layerName The name of the layer to query
+   * @param {String} workspaceOfStyle The workspace of the style, can be undefined
    * @param {String} styleName The name of the style
-   * @param {String} [workspaceOfStyle] The workspace of the style
    * @param {Boolean} [isDefaultStyle=true] If the style should be the default style of the layer
    *
    * @throws Error if request fails
    */
-  async assignStyleToLayer (workspaceOfLayer, layerName, styleName, workspaceOfStyle, isDefaultStyle) {
+  async assignStyleToLayer (workspaceOfLayer, layerName, workspaceOfStyle, styleName, isDefaultStyle) {
     let qualifiedName;
     if (workspaceOfLayer) {
       qualifiedName = `${workspaceOfLayer}:${layerName}`;

--- a/src/style.js
+++ b/src/style.js
@@ -200,7 +200,6 @@ export default class StyleClient {
    * @throws Error if request fails
    */
   async assignStyleToLayer (workspaceOfLayer, layerName, styleName, workspaceOfStyle, isDefaultStyle) {
-
     let qualifiedName;
     if (workspaceOfLayer) {
       qualifiedName = `${workspaceOfLayer}:${layerName}`;

--- a/src/style.js
+++ b/src/style.js
@@ -169,6 +169,10 @@ export default class StyleClient {
    * @returns {Boolean} If the style could be assigned
    */
   async assignStyleToLayer (qualifiedName, styleName, workspaceStyle, isDefaultStyle) {
+    // TODO: add default value
+    // TODO: ensure default value is true or false
+    // TODO: consider removing `?default` if no value provided
+
     try {
       const auth = Buffer.from(this.user + ':' + this.password).toString('base64');
 

--- a/test/test.js
+++ b/test/test.js
@@ -452,7 +452,7 @@ describe('style', () => {
 
     // case: style shall be default style
     isDefaultStyle = true;
-    await grc.styles.assignStyleToLayer(workSpace, featureLayerName, workspaceStyle, styleName, isDefaultStyle);
+    await grc.styles.assignStyleToLayer(workSpace, featureLayerName, workspaceStyle, styleName);
 
     const layerInfo3 = await grc.layers.get(workSpace, featureLayerName)
     const changedDefaultStyleName = layerInfo3.layer.defaultStyle.name;

--- a/test/test.js
+++ b/test/test.js
@@ -438,7 +438,7 @@ describe('style', () => {
     const layerInfo1 = await grc.layers.get(workSpace, featureLayerName)
     const defaultStyleNameBefore = layerInfo1.layer.defaultStyle.name;
 
-    await grc.styles.assignStyleToLayer(workSpace, featureLayerName, styleName, workspaceStyle, isDefaultStyle);
+    await grc.styles.assignStyleToLayer(workSpace, featureLayerName, workspaceStyle, styleName, isDefaultStyle);
 
     const layerInfo2 = await grc.layers.get(workSpace, featureLayerName)
     const defaultStyleNameAfter = layerInfo2.layer.defaultStyle.name;
@@ -452,7 +452,7 @@ describe('style', () => {
 
     // case: style shall be default style
     isDefaultStyle = true;
-    await grc.styles.assignStyleToLayer(workSpace, featureLayerName, styleName, workspaceStyle, isDefaultStyle);
+    await grc.styles.assignStyleToLayer(workSpace, featureLayerName, workspaceStyle, styleName, isDefaultStyle);
 
     const layerInfo3 = await grc.layers.get(workSpace, featureLayerName)
     const changedDefaultStyleName = layerInfo3.layer.defaultStyle.name;

--- a/test/test.js
+++ b/test/test.js
@@ -446,9 +446,9 @@ describe('style', () => {
     expect(defaultStyleNameBefore).to.equal(defaultStyleNameAfter);
 
     const associatedStyleName = layerInfo2.layer.styles.style[0].name;
-    const InputStyleQualifiedName = `${workspaceStyle}:${styleName}`
+    const inputStyleQualifiedName = `${workspaceStyle}:${styleName}`
     // we check if the new style got associated with the layer
-    expect(associatedStyleName).to.equal(InputStyleQualifiedName);
+    expect(associatedStyleName).to.equal(inputStyleQualifiedName);
 
     // case: style shall be default style (default behavior)
     await grc.styles.assignStyleToLayer(workSpace, featureLayerName, workspaceStyle, styleName);
@@ -456,7 +456,7 @@ describe('style', () => {
     const layerInfo3 = await grc.layers.get(workSpace, featureLayerName)
     const changedDefaultStyleName = layerInfo3.layer.defaultStyle.name;
     // we check if the default style got updated
-    expect(changedDefaultStyleName).to.equal(InputStyleQualifiedName);
+    expect(changedDefaultStyleName).to.equal(inputStyleQualifiedName);
   });
 
   it('can get style information', async () => {

--- a/test/test.js
+++ b/test/test.js
@@ -432,10 +432,32 @@ describe('style', () => {
     );
 
     const workspaceStyle = workSpace;
-    const isDefaultStyle = true;
+
+    // case: style shall **not** be default style
+    let isDefaultStyle = false;
+    const layerInfo1 = await grc.layers.get(workSpace, featureLayerName)
+    const defaultStyleNameBefore = layerInfo1.layer.defaultStyle.name;
+
     await grc.styles.assignStyleToLayer(workSpace, featureLayerName, styleName, workspaceStyle, isDefaultStyle);
 
-    // TODO: test option that default style is not provided
+    const layerInfo2 = await grc.layers.get(workSpace, featureLayerName)
+    const defaultStyleNameAfter = layerInfo2.layer.defaultStyle.name;
+    // we check if the default style of before has not changed
+    expect(defaultStyleNameBefore).to.equal(defaultStyleNameAfter);
+
+    const associatedStyleName = layerInfo2.layer.styles.style[0].name;
+    const InputStyleQualifiedName = `${workspaceStyle}:${styleName}`
+    // we check if the new style got associated with the layer
+    expect(associatedStyleName).to.equal(InputStyleQualifiedName);
+
+    // case: style shall be default style
+    isDefaultStyle = true;
+    await grc.styles.assignStyleToLayer(workSpace, featureLayerName, styleName, workspaceStyle, isDefaultStyle);
+
+    const layerInfo3 = await grc.layers.get(workSpace, featureLayerName)
+    const changedDefaultStyleName = layerInfo3.layer.defaultStyle.name;
+    // we check if the default style got updated
+    expect(changedDefaultStyleName).to.equal(InputStyleQualifiedName);
   });
 
   it('can get style information', async () => {

--- a/test/test.js
+++ b/test/test.js
@@ -434,7 +434,7 @@ describe('style', () => {
     const workspaceStyle = workSpace;
 
     // case: style shall **not** be default style
-    let isDefaultStyle = false;
+    const isDefaultStyle = false;
     const layerInfo1 = await grc.layers.get(workSpace, featureLayerName)
     const defaultStyleNameBefore = layerInfo1.layer.defaultStyle.name;
 
@@ -450,8 +450,7 @@ describe('style', () => {
     // we check if the new style got associated with the layer
     expect(associatedStyleName).to.equal(InputStyleQualifiedName);
 
-    // case: style shall be default style
-    isDefaultStyle = true;
+    // case: style shall be default style (default behavior)
     await grc.styles.assignStyleToLayer(workSpace, featureLayerName, workspaceStyle, styleName);
 
     const layerInfo3 = await grc.layers.get(workSpace, featureLayerName)

--- a/test/test.js
+++ b/test/test.js
@@ -435,6 +435,8 @@ describe('style', () => {
     const isDefaultStyle = true;
     const result = await grc.styles.assignStyleToLayer(qualifiedName, styleName, workspaceStyle, isDefaultStyle);
     expect(result).to.be.true;
+
+    // TODO: test option that default style is not provided
   });
 
   it('can get style information', async () => {


### PR DESCRIPTION
- fixes #41
- default behavior is set to use the assigned style as default the default style of the layer
- swap argument order: 1) workspace 2) style - to be consistent with other functions