### PR TITLE
Use provided "nativeName" argument

### DIFF
--- a/src/layer.js
+++ b/src/layer.js
@@ -144,7 +144,7 @@ export default class LayerClient {
     const body = {
       featureType: {
         name: name,
-        nativeName: name,
+        nativeName: nativeName || name,
         title: title || name,
         srs: srs || 'EPSG:4326',
         enabled: enabled,


### PR DESCRIPTION
Uses the provided "nativeName" argument in the function `publishFeatureTypeDefaultDataStore()`. Before it was unused