### PR TITLE
Use provided argument

### DIFF
--- a/src/layer.js
+++ b/src/layer.js
@@ -393,7 +393,7 @@ export default class LayerClient {
             {
               '@key': 'time',
               dimensionInfo: {
-                presentation: 'DISCRETE_INTERVAL',
+                presentation: presentation || 'DISCRETE_INTERVAL',
                 resolution: resolution,
                 units: 'ISO8601',
                 defaultValue: {


### PR DESCRIPTION
Uses a provided argument of `enableTimeCoverage` that was not used before.