### PR TITLE
Update GeoServer version to 2.21.0

### DIFF
--- a/.github/workflows/ci-geoserver-node-client.yml
+++ b/.github/workflows/ci-geoserver-node-client.yml
@@ -10,7 +10,7 @@ jobs:
   run-tests-maintenance:
     runs-on: ubuntu-latest
     env:
-      GEOSERVER_VERSION: 2.19.6
+      GEOSERVER_VERSION: 2.20.4
     steps:
       - uses: actions/checkout@v2
 
@@ -33,7 +33,7 @@ jobs:
   run-tests-stable:
     runs-on: ubuntu-latest
     env:
-      GEOSERVER_VERSION: 2.20.4
+      GEOSERVER_VERSION: 2.21.0
     steps:
       - uses: actions/checkout@v2
 

--- a/README.md
+++ b/README.md
@@ -13,8 +13,9 @@ Detailed [API-Docs](https://meggsimum.github.io/geoserver-node-client/) are auto
 
 Compatible with [GeoServer](https://geoserver.org)
 
+  - v2.21.x
   - v2.20.x
-  - v2.19.x
+  - v2.19.x (no more maintained and officially deprecated)
   - v2.18.x (no more maintained and officially deprecated)
   - v2.17.x (no more maintained and officially deprecated)
 

--- a/test/test.js
+++ b/test/test.js
@@ -472,7 +472,18 @@ describe('style', () => {
     // we check if the default style of before has not changed
     expect(defaultStyleNameBefore).to.equal(defaultStyleNameAfter);
 
-    const associatedStyleName = layerInfo2.layer.styles.style[0].name;
+    let associatedStyleName;
+    // from GeoServer 2.21.0 on, the response of a layer has changed for the "style" property
+    // earlier it was always an array, now it is an object, if only one style is assigned
+    const styleStoredAsArray = Array.isArray(layerInfo2.layer.styles.style);
+    if (styleStoredAsArray) {
+      // GeoServer 2.20.4 and earlier
+      associatedStyleName = layerInfo2.layer.styles.style[0].name;
+    } else {
+      // GeoServer 2.21.0 and later
+      associatedStyleName = layerInfo2.layer.styles.style.name;
+    }
+
     const inputStyleQualifiedName = `${workspaceStyle}:${styleName}`
     // we check if the new style got associated with the layer
     expect(associatedStyleName).to.equal(inputStyleQualifiedName);


### PR DESCRIPTION
Update GeoServer version to 2.21.0
- [x] docker image of newest GeoServer needs to be published first, see https://github.com/meggsimum/geoserver-docker/pull/7

I tested it with a locally built image of GeoServer  2.21.0 and it worked after this fix ce9b2bd 