### PR TITLE
Fix broken logo image in API docs

### DIFF
--- a/DOCS_HOME.md
+++ b/DOCS_HOME.md
@@ -1,6 +1,6 @@
 # GeoServer Node Client
 
-![GeoSever Node Client Logo](/img/geoserver-node-client-logo_150px.png)
+![GeoSever Node Client Logo](geoserver-node-client-logo_150px.png)
 
 Node.js / JavaScript Client for the [GeoServer REST API](https://docs.geoserver.org/stable/en/user/rest/).
 

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "main": "geoserver-rest-client.js",
   "scripts": {
     "demo": "node demo/index.js",
-    "docs": "./node_modules/.bin/jsdoc geoserver-rest-client.js src/*.js DOCS_HOME.md",
+    "docs": "./node_modules/.bin/jsdoc geoserver-rest-client.js src/*.js DOCS_HOME.md && cp img/*.png out/",
     "lint": "eslint src/**/*.js test/**/*.js scripts/**/*.js geoserver-rest-client.js",
     "lint-fix": "eslint --fix  src/**/*.js test/**/*.js scripts/**/*.js geoserver-rest-client.js",
     "pretest": "npm run lint",


### PR DESCRIPTION
Copy over the logo to the out folder of JSDoc. Otherwise it is missing in API Docs.