### PR TITLE
Update currently supported GeoServer versions

### DIFF
--- a/.github/workflows/ci-geoserver-node-client.yml
+++ b/.github/workflows/ci-geoserver-node-client.yml
@@ -10,7 +10,7 @@ jobs:
   run-tests-maintenance:
     runs-on: ubuntu-latest
     env:
-      GEOSERVER_VERSION: 2.20.5
+      GEOSERVER_VERSION: 2.21.2
     steps:
       - uses: actions/checkout@v2
 
@@ -33,7 +33,7 @@ jobs:
   run-tests-stable:
     runs-on: ubuntu-latest
     env:
-      GEOSERVER_VERSION: 2.21.0
+      GEOSERVER_VERSION: 2.22.0
     steps:
       - uses: actions/checkout@v2
 

--- a/DOCS_HOME.md
+++ b/DOCS_HOME.md
@@ -8,8 +8,9 @@ Node.js / JavaScript Client for the [GeoServer REST API](https://docs.geoserver.
 
 Compatible with [GeoServer](https://geoserver.org)
 
+  - v2.22.x
   - v2.21.x
-  - v2.20.x
+  - v2.20.x (no more maintained and officially deprecated)
   - v2.19.x (no more maintained and officially deprecated)
   - v2.18.x (no more maintained and officially deprecated)
   - v2.17.x (no more maintained and officially deprecated)

--- a/README.md
+++ b/README.md
@@ -18,8 +18,9 @@ Detailed [API-Docs](https://meggsimum.github.io/geoserver-node-client/) are auto
 
 Compatible with [GeoServer](https://geoserver.org)
 
+  - v2.22.x
   - v2.21.x
-  - v2.20.x
+  - v2.20.x (no more maintained and officially deprecated)
   - v2.19.x (no more maintained and officially deprecated)
   - v2.18.x (no more maintained and officially deprecated)
   - v2.17.x (no more maintained and officially deprecated)


### PR DESCRIPTION
This updates the currently supported GeoServer versions: `2.21.2 ` and  `2.22.0`.