### PR TITLE
Draft: GeoServer version rotation (2.23.x / 2.22.x)

### DIFF
--- a/.github/workflows/ci-geoserver-node-client.yml
+++ b/.github/workflows/ci-geoserver-node-client.yml
@@ -10,7 +10,7 @@ jobs:
   run-tests-maintenance:
     runs-on: ubuntu-latest
     env:
-      GEOSERVER_VERSION: 2.21.2
+      GEOSERVER_VERSION: 2.22.2
     steps:
       - name: Install program "wait-for-it"
         run: sudo apt install wait-for-it
@@ -38,7 +38,7 @@ jobs:
   run-tests-stable:
     runs-on: ubuntu-latest
     env:
-      GEOSERVER_VERSION: 2.22.0
+      GEOSERVER_VERSION: 2.23.0
     steps:
       - name: Install program "wait-for-it"
         run: sudo apt install wait-for-it

--- a/DOCS_HOME.md
+++ b/DOCS_HOME.md
@@ -8,12 +8,13 @@ Node.js / JavaScript Client for the [GeoServer REST API](https://docs.geoserver.
 
 Compatible with [GeoServer](https://geoserver.org)
 
-  - v2.22.x
-  - v2.21.x
-  - v2.20.x (no more maintained and officially deprecated)
-  - v2.19.x (no more maintained and officially deprecated)
-  - v2.18.x (no more maintained and officially deprecated)
-  - v2.17.x (no more maintained and officially deprecated)
+- v2.23.x
+- v2.22.x
+- v2.21.x (no more maintained and officially deprecated)
+- v2.20.x (no more maintained and officially deprecated)
+- v2.19.x (no more maintained and officially deprecated)
+- v2.18.x (no more maintained and officially deprecated)
+- v2.17.x (no more maintained and officially deprecated)
 
 ### Who do I talk to? ###
 

--- a/README.md
+++ b/README.md
@@ -18,8 +18,9 @@ Detailed [API-Docs](https://meggsimum.github.io/geoserver-node-client/) are auto
 
 Compatible with [GeoServer](https://geoserver.org)
 
+- v2.23.x
 - v2.22.x
-- v2.21.x
+- v2.21.x (no more maintained and officially deprecated)
 - v2.20.x (no more maintained and officially deprecated)
 - v2.19.x (no more maintained and officially deprecated)
 - v2.18.x (no more maintained and officially deprecated)

--- a/test/.env
+++ b/test/.env
@@ -1,5 +1,5 @@
 # will be overwritten by manually set environment variable
-GEOSERVER_VERSION=2.21.2
+GEOSERVER_VERSION=2.23.0
 
 POSTGRES_VERSION=13
 POSTGIS_VERSION=3.2


### PR DESCRIPTION
Upgrade supported GeoServer to current versions: 

- stable: 2.23.x
- maintenance: 2.22.x 