### PR TITLE
Use official GeoServer Docker image in tests

### DIFF
--- a/.github/workflows/ci-geoserver-node-client.yml
+++ b/.github/workflows/ci-geoserver-node-client.yml
@@ -10,7 +10,7 @@ jobs:
   run-tests-maintenance:
     runs-on: ubuntu-latest
     env:
-      GEOSERVER_VERSION: 2.21.2
+      GEOSERVER_VERSION: 2.22.4
     steps:
       - name: Install program "wait-for-it"
         run: sudo apt install wait-for-it
@@ -38,7 +38,7 @@ jobs:
   run-tests-stable:
     runs-on: ubuntu-latest
     env:
-      GEOSERVER_VERSION: 2.22.0
+      GEOSERVER_VERSION: 2.23.2
     steps:
       - name: Install program "wait-for-it"
         run: sudo apt install wait-for-it

--- a/test/docker-compose.yml
+++ b/test/docker-compose.yml
@@ -3,12 +3,13 @@ version: '3'
 services:
 
   geoserver:
-    image: meggsimum/geoserver:${GEOSERVER_VERSION}
+    image: docker.osgeo.org/geoserver:${GEOSERVER_VERSION}
     restart: unless-stopped
     ports:
      - 8080:8080
     environment:
-      - USE_CORS=1
+      - CORS_ENABLED=1
+      - SKIP_DEMO_DATA=true
 
   postgres:
     image: postgis/postgis:${POSTGRES_VERSION}-${POSTGIS_VERSION}

--- a/test/test.js
+++ b/test/test.js
@@ -165,10 +165,8 @@ describe('Namespace', () => {
 });
 
 describe('Datastore', () => {
-  let createdWorkSpace;
-
   before('create workspace', async () => {
-    createdWorkSpace = await grc.workspaces.create(workSpace);
+    await grc.workspaces.create(workSpace);
   });
 
   it('can create a PostGIS store', async () => {
@@ -272,12 +270,13 @@ describe('Datastore', () => {
 
   after('delete Workspace', async () => {
     const recursive = true;
-    await grc.workspaces.delete(createdWorkSpace, recursive);
+    const wsResp = await grc.workspaces.get(workSpace);
+    const wsName = wsResp.workspace.name;
+    await grc.workspaces.delete(wsName, recursive);
   });
 });
 
 describe('Layer', () => {
-  let createdWorkSpace;
   const wmsDataStore = 'my-wms-datastore';
   const wmsLayerName = 'my-wms-layer-name';
   const wmsNativeName = 'mgsm-ger:postal_codes_germany';
@@ -287,7 +286,7 @@ describe('Layer', () => {
   const rasterLayerName = 'my-raster-name';
 
   before('create workspace', async () => {
-    createdWorkSpace = await grc.workspaces.create(workSpace);
+    await grc.workspaces.create(workSpace);
   });
 
   it('can publish a FeatureType from a WFS', async () => {
@@ -480,18 +479,19 @@ describe('Layer', () => {
 
   after('delete Workspace', async () => {
     const recursive = true;
-    await grc.workspaces.delete(createdWorkSpace, recursive);
+    const wsResp = await grc.workspaces.get(workSpace);
+    const wsName = wsResp.workspace.name;
+    await grc.workspaces.delete(wsName, recursive);
   });
 });
 
 describe('Style', () => {
-  let createdWorkSpace;
   const styleName = 'my-style-name';
   const featureLayerName = 'my-feature-layer-name'
   const wfsDataStore = 'my-wfs-datastore';
 
   before('create workspace', async () => {
-    createdWorkSpace = await grc.workspaces.create(workSpace);
+    await grc.workspaces.create(workSpace);
   });
 
   it('can get default styles', async () => {
@@ -607,18 +607,18 @@ describe('Style', () => {
 
   after('delete Workspace', async () => {
     const recursive = true;
-    await grc.workspaces.delete(createdWorkSpace, recursive);
+    const wsResp = await grc.workspaces.get(workSpace);
+    const wsName = wsResp.workspace.name;
+    await grc.workspaces.delete(wsName, recursive);
   });
 });
 
 describe('Security', () => {
-  let createdWorkSpace;
-
   const dummyUser = 'dummyUser';
   const dummyPassword = 'dummyPassword';
 
   before('create workspace', async () => {
-    createdWorkSpace = await grc.workspaces.create(workSpace);
+    await grc.workspaces.create(workSpace);
   });
 
   it('can create a user', async () => {
@@ -636,7 +636,9 @@ describe('Security', () => {
 
   after(async () => {
     const recursive = true;
-    await grc.workspaces.delete(createdWorkSpace, recursive);
+    const wsResp = await grc.workspaces.get(workSpace);
+    const wsName = wsResp.workspace.name;
+    await grc.workspaces.delete(wsName, recursive);
   });
 });
 


### PR DESCRIPTION
Change test suite to use the official GeoServer image.

From version `2.23.0` the return type / value of  REST API to create a workspace changed. Previously the name of the newly created workspace was returned, afterwards nothing is returned. The adaption of the test suite can now handle both cases.