### PR TITLE
Ensure returning created workspace name

### DIFF
--- a/src/workspace.js
+++ b/src/workspace.js
@@ -86,7 +86,7 @@ export default class WorkspaceClient {
   async create (name) {
     const body = {
       workspace: {
-        name: name
+        name
       }
     };
 
@@ -109,8 +109,9 @@ export default class WorkspaceClient {
           throw new GeoServerResponseError(null, geoServerResponse);
       }
     }
-
-    return response.text();
+    // query the WS object again to return the name of the created WS
+    const wsObject = await this.get(name);
+    return wsObject.workspace.name;
   }
 
   /**

--- a/test/test.js
+++ b/test/test.js
@@ -100,7 +100,8 @@ describe('Workspace', () => {
   });
 
   it('creates one workspace', async () => {
-    await grc.workspaces.create(workSpace);
+    const wsName = await grc.workspaces.create(workSpace);
+    expect(wsName).to.equal(workSpace, 'incorrect WS name returned by "create"');
   });
 
   it('has one workspace', async () => {


### PR DESCRIPTION
This fixes the missing return of the created workspace name in the `grc.workspaces.create` function. Reason was the changed REST API behavior in GeoServer 2.23, where the name was no more returned in the REST call.

Fixes #128

/cc @hblitza