### PR TITLE
Update CI actions

### DIFF
--- a/.github/workflows/ci-geoserver-node-client.yml
+++ b/.github/workflows/ci-geoserver-node-client.yml
@@ -15,7 +15,7 @@ jobs:
       - name: Install program "wait-for-it"
         run: sudo apt install wait-for-it
 
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
 
       # In this step, this action saves a list of existing images,
       # the cache is created without them in the post run.
@@ -43,7 +43,7 @@ jobs:
       - name: Install program "wait-for-it"
         run: sudo apt install wait-for-it
 
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
 
       # In this step, this action saves a list of existing images,
       # the cache is created without them in the post run.

--- a/.github/workflows/ci-geoserver-node-client.yml
+++ b/.github/workflows/ci-geoserver-node-client.yml
@@ -15,6 +15,11 @@ jobs:
       - name: Install program "wait-for-it"
         run: sudo apt install wait-for-it
 
+      # use Node.js 16 instead of deprecated v12 in Ubuntu image
+      - uses: actions/setup-node@v3
+        with:
+          node-version: '16'
+
       - uses: actions/checkout@v4
 
       # In this step, this action saves a list of existing images,
@@ -42,6 +47,11 @@ jobs:
     steps:
       - name: Install program "wait-for-it"
         run: sudo apt install wait-for-it
+
+      # use Node.js 16 instead of deprecated v12 in Ubuntu image
+      - uses: actions/setup-node@v3
+        with:
+          node-version: '16'
 
       - uses: actions/checkout@v4
 

--- a/.github/workflows/ci-publish-docs.yml
+++ b/.github/workflows/ci-publish-docs.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v2.3.1
+        uses: actions/checkout@v4
 
       - name: Install and Build
         run: |

--- a/.github/workflows/ci-publish-docs.yml
+++ b/.github/workflows/ci-publish-docs.yml
@@ -7,6 +7,11 @@ jobs:
   build-and-publish-docs:
     runs-on: ubuntu-latest
     steps:
+      # use Node.js 16 instead of deprecated v12 in Ubuntu image
+      - uses: actions/setup-node@v3
+        with:
+          node-version: '16'
+
       - name: Checkout
         uses: actions/checkout@v4
 


### PR DESCRIPTION
This PR updates the CI actions:

- use checkout action in version 4
- use Node.js 16 instead of deprecated Node.js 12