### PR TITLE
Update current GS versions in documentation

### DIFF
--- a/DOCS_HOME.md
+++ b/DOCS_HOME.md
@@ -8,8 +8,9 @@ Node.js / JavaScript Client for the [GeoServer REST API](https://docs.geoserver.
 
 Compatible with [GeoServer](https://geoserver.org)
 
+  - v2.25.x
   - v2.24.x
-  - v2.23.x
+  - v2.23.x (no more maintained and officially deprecated)
   - v2.22.x (no more maintained and officially deprecated)
   - v2.21.x (no more maintained and officially deprecated)
   - v2.20.x (no more maintained and officially deprecated)

--- a/README.md
+++ b/README.md
@@ -18,8 +18,9 @@ Detailed [API-Docs](https://meggsimum.github.io/geoserver-node-client/) are auto
 
 Compatible with [GeoServer](https://geoserver.org)
 
+- v2.25.x
 - v2.24.x
-- v2.23.x
+- v2.23.x (no more maintained and officially deprecated)
 - v2.22.x (no more maintained and officially deprecated)
 - v2.21.x (no more maintained and officially deprecated)
 - v2.20.x (no more maintained and officially deprecated)


### PR DESCRIPTION
Sets the current GeoServer versions `maintenance` `2.24.x` and `stable` `2.25.x` in the documentation files.