### PR TITLE
Add "release:dry" npm script

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "pretest": "npm run lint",
     "test": "mocha --timeout 10000",
     "release": "release-it",
+    "release:dry": "release-it --dry-run",
     "build": "npm run build:clean && npm run build:babel && npm run build:fixup",
     "build:clean": "rm -rf dist",
     "build:babel": "babel geoserver-rest-client.js -d dist && babel src -d dist/src",


### PR DESCRIPTION
This adds a npm script `release:dry`, which allows to perform a [dry-run](https://github.com/release-it/release-it/blob/HEAD/docs/dry-runs.md) of the release process done with [release-it](https://www.npmjs.com/package/release-it).