### PR TITLE
Upgrade supported GeoServer versions v2.26.x / v2.25.x

### DIFF
--- a/.github/workflows/ci-geoserver-node-client.yml
+++ b/.github/workflows/ci-geoserver-node-client.yml
@@ -10,7 +10,7 @@ jobs:
   run-tests-maintenance:
     runs-on: ubuntu-latest
     env:
-      GEOSERVER_VERSION: 2.25.3
+      GEOSERVER_VERSION: 2.25.6
     steps:
       - name: Install program "wait-for-it"
         run: sudo apt install wait-for-it
@@ -29,7 +29,19 @@ jobs:
       # Ignore the failure of a step and avoid terminating the job.
         continue-on-error: true
 
-      - run: docker compose -f test/docker-compose.yml up -d
+      - name: Create empty temp directory as volume for GeoServer data
+        run: |
+          RANDOM_FOLDER="docker-temp-$(uuidgen)"
+          TEMP_DIR="${{ runner.temp }}/$RANDOM_FOLDER"
+          echo "TEMP_DIR=$TEMP_DIR" >> $GITHUB_ENV
+          rm -rf "$TEMP_DIR"
+          mkdir -p "$TEMP_DIR"
+          echo "Temp directory is ready at $TEMP_DIR"
+
+      - name: Run docker-compose test setup
+        run: |
+          export TEMP_DIR="$TEMP_DIR"
+          docker compose -f test/docker-compose.yml up -d
 
       # finishes when tomcat of GeoServer is running
       - run: wait-for-it "localhost:8080"
@@ -43,7 +55,7 @@ jobs:
   run-tests-stable:
     runs-on: ubuntu-latest
     env:
-      GEOSERVER_VERSION: 2.26.0
+      GEOSERVER_VERSION: 2.26.2
     steps:
       - name: Install program "wait-for-it"
         run: sudo apt install wait-for-it
@@ -62,7 +74,19 @@ jobs:
       # Ignore the failure of a step and avoid terminating the job.
         continue-on-error: true
 
-      - run: docker compose -f test/docker-compose.yml up -d
+      - name: Create empty temp directory as volume for GeoServer data
+        run: |
+          RANDOM_FOLDER="docker-temp-$(uuidgen)"
+          TEMP_DIR="${{ runner.temp }}/$RANDOM_FOLDER"
+          echo "TEMP_DIR=$TEMP_DIR" >> $GITHUB_ENV
+          rm -rf "$TEMP_DIR"
+          mkdir -p "$TEMP_DIR"
+          echo "Temp directory is ready at $TEMP_DIR"
+
+      - name: Run docker-compose test setup
+        run: |
+          export TEMP_DIR="$TEMP_DIR"
+          docker compose -f test/docker-compose.yml up -d
 
       # finishes when tomcat of GeoServer is running
       - run: wait-for-it "localhost:8080"

--- a/.github/workflows/ci-geoserver-node-client.yml
+++ b/.github/workflows/ci-geoserver-node-client.yml
@@ -50,6 +50,7 @@ jobs:
       - run: wget http://localhost:8080/geoserver/web
 
       - run: npm install
+      - run: npm run test:reset-gs # ensure empty GeoServer
       - run: npm run test
 
   run-tests-stable:
@@ -95,4 +96,5 @@ jobs:
       - run: wget http://localhost:8080/geoserver/web
 
       - run: npm install
+      - run: npm run test:reset-gs # ensure empty GeoServer
       - run: npm run test

--- a/.github/workflows/ci-geoserver-node-client.yml
+++ b/.github/workflows/ci-geoserver-node-client.yml
@@ -11,6 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     env:
       GEOSERVER_VERSION: 2.25.6
+      GEOSERVER_PORT: 8080
     steps:
       - name: Install program "wait-for-it"
         run: sudo apt install wait-for-it
@@ -57,6 +58,7 @@ jobs:
     runs-on: ubuntu-latest
     env:
       GEOSERVER_VERSION: 2.26.2
+      GEOSERVER_PORT: 8081
     steps:
       - name: Install program "wait-for-it"
         run: sudo apt install wait-for-it
@@ -90,10 +92,10 @@ jobs:
           docker compose -f test/docker-compose.yml up -d
 
       # finishes when tomcat of GeoServer is running
-      - run: wait-for-it "localhost:8080"
+      - run: wait-for-it "localhost:8081"
 
       # we use wget to ensure that GeoServer is running
-      - run: wget http://localhost:8080/geoserver/web
+      - run: wget http://localhost:8081/geoserver/web
 
       - run: npm install
       - run: npm run test:reset-gs # ensure empty GeoServer

--- a/.github/workflows/ci-geoserver-node-client.yml
+++ b/.github/workflows/ci-geoserver-node-client.yml
@@ -10,7 +10,7 @@ jobs:
   run-tests-maintenance:
     runs-on: ubuntu-latest
     env:
-      GEOSERVER_VERSION: 2.24.4
+      GEOSERVER_VERSION: 2.25.3
     steps:
       - name: Install program "wait-for-it"
         run: sudo apt install wait-for-it
@@ -43,7 +43,7 @@ jobs:
   run-tests-stable:
     runs-on: ubuntu-latest
     env:
-      GEOSERVER_VERSION: 2.25.2
+      GEOSERVER_VERSION: 2.26.0
     steps:
       - name: Install program "wait-for-it"
         run: sudo apt install wait-for-it

--- a/DOCS_HOME.md
+++ b/DOCS_HOME.md
@@ -8,8 +8,9 @@ Node.js / JavaScript Client for the [GeoServer REST API](https://docs.geoserver.
 
 Compatible with [GeoServer](https://geoserver.org)
 
+  - v2.26.x
   - v2.25.x
-  - v2.24.x
+  - v2.24.x (no more maintained and officially deprecated)
   - v2.23.x (no more maintained and officially deprecated)
   - v2.22.x (no more maintained and officially deprecated)
   - v2.21.x (no more maintained and officially deprecated)

--- a/README.md
+++ b/README.md
@@ -18,8 +18,9 @@ Detailed [API-Docs](https://meggsimum.github.io/geoserver-node-client/) are auto
 
 Compatible with [GeoServer](https://geoserver.org)
 
+- v2.26.x
 - v2.25.x
-- v2.24.x
+- v2.24.x (no more maintained and officially deprecated)
 - v2.23.x (no more maintained and officially deprecated)
 - v2.22.x (no more maintained and officially deprecated)
 - v2.21.x (no more maintained and officially deprecated)

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "lint-fix": "eslint --fix  src/**/*.js test/**/*.js scripts/**/*.js geoserver-rest-client.js",
     "pretest": "npm run lint",
     "test": "mocha --timeout 10000",
+    "test:reset-gs": "node test/reset-gs.js",
     "release": "release-it",
     "release:dry": "release-it --dry-run",
     "build": "npm run build:clean && npm run build:babel && npm run build:fixup",

--- a/test/docker-compose.yml
+++ b/test/docker-compose.yml
@@ -9,9 +9,13 @@ services:
      - 8080:8080
     volumes:
      - "${TEMP_DIR}:/opt/geoserver_data/:Z"
+
+
+# REMAINING TODO: Check with GS 2.26 and check why REST-API not functional, maybe add user for REST API due to empty geoserver_data
+
     environment:
       - CORS_ENABLED=1
-      - SKIP_DEMO_DATA=true
+      # - SKIP_DEMO_DATA=true
 
   postgres:
     image: postgis/postgis:${POSTGRES_VERSION}-${POSTGIS_VERSION}

--- a/test/docker-compose.yml
+++ b/test/docker-compose.yml
@@ -7,6 +7,8 @@ services:
     restart: unless-stopped
     ports:
      - 8080:8080
+    volumes:
+     - "${TEMP_DIR}:/opt/geoserver_data/:Z"
     environment:
       - CORS_ENABLED=1
       - SKIP_DEMO_DATA=true

--- a/test/docker-compose.yml
+++ b/test/docker-compose.yml
@@ -9,13 +9,8 @@ services:
      - ${GEOSERVER_PORT}:8080
     volumes:
      - "${TEMP_DIR}:/opt/geoserver_data/:Z"
-
-
-# REMAINING TODO: Check with GS 2.26 and check why REST-API not functional, maybe add user for REST API due to empty geoserver_data
-
     environment:
       - CORS_ENABLED=1
-      # - SKIP_DEMO_DATA=true
 
   postgres:
     image: postgis/postgis:${POSTGRES_VERSION}-${POSTGIS_VERSION}

--- a/test/docker-compose.yml
+++ b/test/docker-compose.yml
@@ -6,7 +6,7 @@ services:
     image: docker.osgeo.org/geoserver:${GEOSERVER_VERSION}
     restart: unless-stopped
     ports:
-     - 8080:8080
+     - ${GEOSERVER_PORT}:8080
     volumes:
      - "${TEMP_DIR}:/opt/geoserver_data/:Z"
 

--- a/test/reset-gs.js
+++ b/test/reset-gs.js
@@ -16,20 +16,20 @@ main();
  * Async main function triggering all required requests
  */
 async function main () {
+  // delete all workspaces
   const recurse = true;
-
   const allWs = await grc.workspaces.getAll();
   const wsArray = allWs.workspaces.workspace;
   for (let index = 0; index < wsArray.length; index++) {
     const wsObj = wsArray[index];
     let wsName = wsObj.name;
-    // hack: add .json to get first '.' ignored by GS
-    if (wsName === 'it.geosolutions') {
+    // hack: add .json to get other '.' in name ignored by GS
+    if (wsName.includes('.') === true) {
       wsName += '.json';
     }
 
     try {
-      console.info('Deleting', wsName, '...');
+      console.info('Deleting workspace', wsName, '...');
       await grc.workspaces.delete(wsName, recurse);
       console.info('... done');
     } catch (error) {
@@ -37,7 +37,9 @@ async function main () {
     }
   }
 
+  // delete all styles
   const defaultStyles = await grc.styles.getDefaults();
+  // following styles are not allowed to delete by GS
   const nonDeletable = [
     'generic',
     'line',
@@ -53,7 +55,7 @@ async function main () {
       const styleName = styleObj.name;
       try {
         if (!nonDeletable.includes(styleName)) {
-          console.log('Deleting style', styleName);
+          console.info('Deleting style', styleName, '...');
           await grc.styles.delete(undefined, styleName, recurse, purge);
           console.info('... done');
         }

--- a/test/reset-gs.js
+++ b/test/reset-gs.js
@@ -1,34 +1,36 @@
 import { GeoServerRestClient } from '../geoserver-rest-client.js';
 
+/**
+ * Helper script to empty a default GeoServer instance
+ */
+
 const port = process.env.GEOSERVER_PORT || 8080;
 const url = `http://localhost:${port}/geoserver/rest/`;
 const user = 'admin';
 const pw = 'geoserver';
 const grc = new GeoServerRestClient(url, user, pw);
 
-const wsToDelete = [
-  'cite',
-  'it.geosolutions.json', // hack: add .json to get first '.' ignored by GS
-  'ne',
-  'nurc',
-  'sde',
-  'sf',
-  'tiger',
-  'topp'
-];
-
 main();
 
 /**
- * Async function containing all demo request
+ * Async main function triggering all required requests
  */
 async function main () {
   const recurse = true;
-  for (let index = 0; index < wsToDelete.length; index++) {
-    const ws = wsToDelete[index];
-    console.info('Deleting', ws, '...');
+
+  const allWs = await grc.workspaces.getAll();
+  const wsArray = allWs.workspaces.workspace;
+  for (let index = 0; index < wsArray.length; index++) {
+    const wsObj = wsArray[index];
+    let wsName = wsObj.name;
+    // hack: add .json to get first '.' ignored by GS
+    if (wsName === 'it.geosolutions') {
+      wsName += '.json';
+    }
+
     try {
-      await grc.workspaces.delete(ws, recurse);
+      console.info('Deleting', wsName, '...');
+      await grc.workspaces.delete(wsName, recurse);
       console.info('... done');
     } catch (error) {
       console.error(error);

--- a/test/reset-gs.js
+++ b/test/reset-gs.js
@@ -1,0 +1,63 @@
+import { GeoServerRestClient } from '../geoserver-rest-client.js';
+
+const port = process.env.GEOSERVER_PORT || 8080;
+const url = `http://localhost:${port}/geoserver/rest/`;
+const user = 'admin';
+const pw = 'geoserver';
+const grc = new GeoServerRestClient(url, user, pw);
+
+const wsToDelete = [
+  'cite',
+  'it.geosolutions.json', // hack: add .json to get first '.' ignored by GS
+  'ne',
+  'nurc',
+  'sde',
+  'sf',
+  'tiger',
+  'topp'
+];
+
+main();
+
+/**
+ * Async function containing all demo request
+ */
+async function main () {
+  const recurse = true;
+  for (let index = 0; index < wsToDelete.length; index++) {
+    const ws = wsToDelete[index];
+    console.info('Deleting', ws, '...');
+    try {
+      await grc.workspaces.delete(ws, recurse);
+      console.info('... done');
+    } catch (error) {
+      console.error(error);
+    }
+  }
+
+  const defaultStyles = await grc.styles.getDefaults();
+  const nonDeletable = [
+    'generic',
+    'line',
+    'point',
+    'polygon',
+    'raster'
+  ];
+  const purge = true;
+  const defaultStylesArray = defaultStyles.styles.style;
+  if (defaultStylesArray) {
+    for (let index = 0; index < defaultStylesArray.length; index++) {
+      const styleObj = defaultStylesArray[index];
+      const styleName = styleObj.name;
+      try {
+        if (!nonDeletable.includes(styleName)) {
+          console.log('Deleting style', styleName);
+          await grc.styles.delete(undefined, styleName, recurse, purge);
+          console.info('... done');
+        }
+      } catch (error) {
+        console.error(error);
+      }
+    }
+  }
+}

--- a/test/test.js
+++ b/test/test.js
@@ -3,7 +3,8 @@
 import { expect } from 'chai';
 import { GeoServerRestClient } from '../geoserver-rest-client.js';
 
-const url = 'http://localhost:8080/geoserver/rest/';
+const port = process.env.GEOSERVER_PORT;
+const url = `http://localhost:${port}/geoserver/rest/`;
 const user = 'admin';
 const pw = 'geoserver';
 const grc = new GeoServerRestClient(url, user, pw);


### PR DESCRIPTION
This PR upgrades the supported GeoServer versions to `v2.26.x` (stable) and `v2.25.x` (maintenance).

Since v2.26 the CI had to be adapted because of an error causing a non-functional GeoServer REST API, when using the the flag `SKIP_DEMO_DATA` in the official GeoServer Docker image. Therefore we mount our own volume as GeoServer data and run a script to remove the GeoServer demo data before each test run.