### PR TITLE
Upgrade to GeoServer v2.26.3 / v2.27.1

### DIFF
--- a/.github/workflows/ci-geoserver-node-client.yml
+++ b/.github/workflows/ci-geoserver-node-client.yml
@@ -10,7 +10,7 @@ jobs:
   run-tests-maintenance:
     runs-on: ubuntu-latest
     env:
-      GEOSERVER_VERSION: 2.25.6
+      GEOSERVER_VERSION: 2.26.3
       GEOSERVER_PORT: 8080
     steps:
       - name: Install program "wait-for-it"
@@ -57,7 +57,7 @@ jobs:
   run-tests-stable:
     runs-on: ubuntu-latest
     env:
-      GEOSERVER_VERSION: 2.26.2
+      GEOSERVER_VERSION: 2.27.1
       GEOSERVER_PORT: 8081
     steps:
       - name: Install program "wait-for-it"

--- a/DOCS_HOME.md
+++ b/DOCS_HOME.md
@@ -8,16 +8,17 @@ Node.js / JavaScript Client for the [GeoServer REST API](https://docs.geoserver.
 
 Compatible with [GeoServer](https://geoserver.org)
 
-  - v2.26.x
-  - v2.25.x
-  - v2.24.x (no more maintained and officially deprecated)
-  - v2.23.x (no more maintained and officially deprecated)
-  - v2.22.x (no more maintained and officially deprecated)
-  - v2.21.x (no more maintained and officially deprecated)
-  - v2.20.x (no more maintained and officially deprecated)
-  - v2.19.x (no more maintained and officially deprecated)
-  - v2.18.x (no more maintained and officially deprecated)
-  - v2.17.x (no more maintained and officially deprecated)
+- v2.27.x
+- v2.26.x
+- v2.25.x (no more maintained and officially deprecated)
+- v2.24.x (no more maintained and officially deprecated)
+- v2.23.x (no more maintained and officially deprecated)
+- v2.22.x (no more maintained and officially deprecated)
+- v2.21.x (no more maintained and officially deprecated)
+- v2.20.x (no more maintained and officially deprecated)
+- v2.19.x (no more maintained and officially deprecated)
+- v2.18.x (no more maintained and officially deprecated)
+- v2.17.x (no more maintained and officially deprecated)
 
 ### Who do I talk to? ###
 

--- a/README.md
+++ b/README.md
@@ -18,8 +18,9 @@ Detailed [API-Docs](https://meggsimum.github.io/geoserver-node-client/) are auto
 
 Compatible with [GeoServer](https://geoserver.org)
 
+- v2.27.x
 - v2.26.x
-- v2.25.x
+- v2.25.x (no more maintained and officially deprecated)
 - v2.24.x (no more maintained and officially deprecated)
 - v2.23.x (no more maintained and officially deprecated)
 - v2.22.x (no more maintained and officially deprecated)


### PR DESCRIPTION
Upgrade CI to current GeoServer versions  `2.26.3` (maintenance) / `2.27.1` (stable).