### PR TITLE
Fix CI unit tests

### DIFF
--- a/test/test.js
+++ b/test/test.js
@@ -436,7 +436,7 @@ describe('Layer', () => {
 
   it('can create Coverage layer', async () => {
     const geotiff = 'test/sample_data/world.tif';
-    grc.datastores.createGeotiffFromFile(
+    await grc.datastores.createGeotiffFromFile(
       workSpace,
       rasterStoreName,
       rasterLayerName,


### PR DESCRIPTION
Fixes the CI unit tests by adding a missing `await`. Otherwise the expected value does not match randomly due to possible timing issues.