### PR TITLE
Update GeoServer to version 2.27.2 in 'run-tests-stable'

### DIFF
--- a/.github/workflows/ci-geoserver-node-client.yml
+++ b/.github/workflows/ci-geoserver-node-client.yml
@@ -57,7 +57,7 @@ jobs:
   run-tests-stable:
     runs-on: ubuntu-latest
     env:
-      GEOSERVER_VERSION: 2.27.1
+      GEOSERVER_VERSION: 2.27.2
       GEOSERVER_PORT: 8081
     steps:
       - name: Install program "wait-for-it"


### PR DESCRIPTION
Updates the GeoServer to version `2.27.2` in CI job `run-tests-stable`.