### PR TITLE
Upgrade stable GeoServer version to v2.28.3 in CI

### DIFF
--- a/.github/workflows/ci-geoserver-node-client.yml
+++ b/.github/workflows/ci-geoserver-node-client.yml
@@ -57,7 +57,7 @@ jobs:
   run-tests-stable:
     runs-on: ubuntu-latest
     env:
-      GEOSERVER_VERSION: 2.28.2
+      GEOSERVER_VERSION: 2.28.3
       GEOSERVER_PORT: 8081
     steps:
       - name: Install program "wait-for-it"


### PR DESCRIPTION
Upgrades to the current stable GeoServer version to `v2.28.3` in CI.