### PR TITLE
Update GeoServer versions in CI (GeoServer 3)

### DIFF
--- a/.github/workflows/ci-geoserver-node-client.yml
+++ b/.github/workflows/ci-geoserver-node-client.yml
@@ -10,7 +10,7 @@ jobs:
   run-tests-maintenance:
     runs-on: ubuntu-latest
     env:
-      GEOSERVER_VERSION: 2.27.5
+      GEOSERVER_VERSION: 2.28.4
       GEOSERVER_PORT: 8080
     steps:
       - name: Install program "wait-for-it"
@@ -57,7 +57,7 @@ jobs:
   run-tests-stable:
     runs-on: ubuntu-latest
     env:
-      GEOSERVER_VERSION: 2.28.3
+      GEOSERVER_VERSION: 3.0.0
       GEOSERVER_PORT: 8081
     steps:
       - name: Install program "wait-for-it"

--- a/DOCS_HOME.md
+++ b/DOCS_HOME.md
@@ -8,8 +8,9 @@ Node.js / JavaScript Client for the [GeoServer REST API](https://docs.geoserver.
 
 Compatible with [GeoServer](https://geoserver.org)
 
+- v3.0.x
 - v2.28.x
-- v2.27.x
+- v2.27.x (no more maintained and officially deprecated)
 - v2.26.x (no more maintained and officially deprecated)
 - v2.25.x (no more maintained and officially deprecated)
 - v2.24.x (no more maintained and officially deprecated)

--- a/README.md
+++ b/README.md
@@ -18,8 +18,9 @@ Detailed [API-Docs](https://meggsimum.github.io/geoserver-node-client/) are auto
 
 Compatible with [GeoServer](https://geoserver.org)
 
+- v3.0.x
 - v2.28.x
-- v2.27.x
+- v2.27.x (no more maintained and officially deprecated)
 - v2.26.x (no more maintained and officially deprecated)
 - v2.25.x (no more maintained and officially deprecated)
 - v2.24.x (no more maintained and officially deprecated)
@@ -117,14 +118,14 @@ A request either succeeds or throws the custom `GeoServerResponseError`. It has 
 First start a test setup using this Docker compose file:
 
 ```shell
-GEOSERVER_VERSION=2.28.0 TEMP_DIR=/tmp/gs docker compose -f test/docker-compose.yml up
+GEOSERVER_VERSION=3.0.0 TEMP_DIR=/tmp/gs docker compose -f test/docker-compose.yml up
 ```
 
 Then, in an other terminal, run:
 
 ```shell
 # specify the GeoServer version and run the test suite
-GEOSERVER_VERSION=2.28.0 npm run test
+GEOSERVER_VERSION=3.0.0 npm run test
 ```
 
 ## Release


### PR DESCRIPTION
Updates the GeoServer versions in CI to the current versions:

- `stable`: `3.0.0`
- `maintenance`: `2.28.4`