### PR TITLE
Upgrade Node.js in CI to v24

### DIFF
--- a/.github/workflows/ci-geoserver-node-client.yml
+++ b/.github/workflows/ci-geoserver-node-client.yml
@@ -16,10 +16,10 @@ jobs:
       - name: Install program "wait-for-it"
         run: sudo apt install wait-for-it
 
-      # use Node.js 22 instead of deprecated v12 in Ubuntu image
+      # use a current Node.js version instead of deprecated v12 in Ubuntu image
       - uses: actions/setup-node@v3
         with:
-          node-version: '22'
+          node-version: '24'
 
       - uses: actions/checkout@v4
 
@@ -63,10 +63,10 @@ jobs:
       - name: Install program "wait-for-it"
         run: sudo apt install wait-for-it
 
-      # use Node.js 22 instead of deprecated v12 in Ubuntu image
+      # use a current Node.js version instead of deprecated v12 in Ubuntu image
       - uses: actions/setup-node@v3
         with:
-          node-version: '22'
+          node-version: '24'
 
       - uses: actions/checkout@v4
 

--- a/.github/workflows/ci-publish-docs.yml
+++ b/.github/workflows/ci-publish-docs.yml
@@ -10,7 +10,7 @@ jobs:
       # use a current Node.js version instead of deprecated v12 in Ubuntu image
       - uses: actions/setup-node@v3
         with:
-          node-version: '22'
+          node-version: '24'
 
       - name: Checkout
         uses: actions/checkout@v4


### PR DESCRIPTION
Upgrades Node.js used in CI to version 24 (active LTS).