### PR TITLE
Follow-up for TypesScript types introduction

### DIFF
--- a/.github/workflows/ci-geoserver-node-client.yml
+++ b/.github/workflows/ci-geoserver-node-client.yml
@@ -7,6 +7,20 @@ on:
     branches:
       - main
 jobs:
+  check-types:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v3
+        with:
+          node-version: '24'
+
+      - run: npm install
+
+      - name: Check TypeScript declaration generation
+        run: npm run build:types
+
   run-tests-maintenance:
     runs-on: ubuntu-latest
     env:

--- a/package-lock.json
+++ b/package-lock.json
@@ -28,7 +28,7 @@
         "neostandard": "^0.13.0",
         "prettier": "^3.6.1",
         "release-it": "^20.0.0",
-        "typescript": "^5.9.3"
+        "typescript": "^6.0.3"
       }
     },
     "node_modules/@babel/cli": {
@@ -9066,9 +9066,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "5.9.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
-      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
+      "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,6 +18,7 @@
         "@babel/plugin-transform-runtime": "^8.0.0",
         "@babel/preset-env": "^8.0.0",
         "@eslint/compat": "^2.0.0",
+        "@types/node": "^26.0.0",
         "chai": "^6.0.1",
         "eslint": "^9.29.0",
         "eslint-config-prettier": "^10.1.5",
@@ -26,7 +27,8 @@
         "mocha": "^11.7.1",
         "neostandard": "^0.13.0",
         "prettier": "^3.6.1",
-        "release-it": "^20.0.0"
+        "release-it": "^20.0.0",
+        "typescript": "^5.9.3"
       }
     },
     "node_modules/@babel/cli": {
@@ -2652,6 +2654,16 @@
       "integrity": "sha512-RGdgjQUZba5p6QEFAVx2OGb8rQDL/cPRG7GiedRzMcJ1tYnUANBncjbSB1NRGwbvjcPeikRABz2nshyPk1bhWg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@types/node": {
+      "version": "26.0.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-26.0.0.tgz",
+      "integrity": "sha512-vf2YFi1iY9lHGwNJMs01biZFbKJkrZR1T6/MlzjhJLPdntOHLhTrDSnSVcdtvjihi4VQNlrFRIxLsDBlQpAipA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~8.3.0"
+      }
     },
     "node_modules/@types/parse-path": {
       "version": "7.0.3",
@@ -9054,12 +9066,11 @@
       }
     },
     "node_modules/typescript": {
-      "version": "6.0.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
-      "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -9134,6 +9145,13 @@
       "engines": {
         "node": ">=20.18.1"
       }
+    },
+    "node_modules/undici-types": {
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-8.3.0.tgz",
+      "integrity": "sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/unicode-canonical-property-names-ecmascript": {
       "version": "2.0.1",

--- a/package.json
+++ b/package.json
@@ -60,6 +60,6 @@
     "neostandard": "^0.13.0",
     "prettier": "^3.6.1",
     "release-it": "^20.0.0",
-    "typescript": "^5.9.3"
+    "typescript": "^6.0.3"
   }
 }

--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
     "@babel/plugin-transform-runtime": "^8.0.0",
     "@babel/preset-env": "^8.0.0",
     "@eslint/compat": "^2.0.0",
+    "@types/node": "^26.0.0",
     "chai": "^6.0.1",
     "eslint": "^9.29.0",
     "eslint-config-prettier": "^10.1.5",

--- a/src/datastore.js
+++ b/src/datastore.js
@@ -214,7 +214,7 @@ export default class DatastoreClient {
    * @param {String} coverageStore The name of the new GeoTIFF store
    * @param {String} layerName The published name of the new layer
    * @param {String} layerTitle The published title of the new layer
-   * @param {Stream} readStream The stream of the GeoTIFF file
+   * @param {import("fs").ReadStream} readStream The stream of the GeoTIFF file
    * @param {Number} fileSizeInBytes The number of bytes of the stream
    *
    * @throws Error if request fails

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,6 +2,7 @@
   "compilerOptions": {
     "allowJs": true,
     "declaration": true,
+    "skipLibCheck": true,
     "emitDeclarationOnly": true,
     "outDir": "./dist/types",
     "rootDir": ".",


### PR DESCRIPTION
This adds some follow-ups for the TypesScript types introduction (#420):

- Upgrade TypeScript to version 6
- Fix some automatic type detection
- Add CI job to error-check type generation

/cc @AdelinoGP 