### PR TITLE
Fix JsDoc syntax in DataStore client

### DIFF
--- a/src/datastore.js
+++ b/src/datastore.js
@@ -214,7 +214,7 @@ export default class DatastoreClient {
    * @param {String} coverageStore The name of the new GeoTIFF store
    * @param {String} layerName The published name of the new layer
    * @param {String} layerTitle The published title of the new layer
-   * @param {import("fs").ReadStream} readStream The stream of the GeoTIFF file
+   * @param {fs.ReadStream} readStream The stream of the GeoTIFF file
    * @param {Number} fileSizeInBytes The number of bytes of the stream
    *
    * @throws Error if request fails


### PR DESCRIPTION
Minor fix to JsDoc syntax in DataStore client.