### PR TITLE
Add functions to publish geopackage file

### DIFF
--- a/src/datastore.js
+++ b/src/datastore.js
@@ -634,4 +634,61 @@ export default class DatastoreClient {
       throw new GeoServerResponseError(null, geoServerResponse);
     }
   }
+
+  /**
+   * Creates a GeoPackage store from a stream containing a .gpkg file and publishes it as layer.
+   * Data will be uploaded to GeoServer's platform.
+   *
+   * @param {String} workspace The WS to create the data store in
+   * @param {String} dataStore The data store name
+   * @param {fs.ReadStream} readStream The stream of the GeoTIFF file
+   * @param {Number} fileSizeInBytes The number of bytes of the stream
+   * @param {String} [fileName] Target file name on server
+   */
+  async createGpkgFromStream(workspace, dataStore, readStream, fileSizeInBytes, fileName) {
+    let url =
+      this.url +
+      'workspaces/' +
+      workspace +
+      '/datastores/' +
+      dataStore +
+      '/file.gpkg?update=overwrite';
+
+    if (fileName) {
+      url += '&filename=' + fileName;
+    }
+
+    const response = await fetch(url, {
+      credentials: 'include',
+      method: 'PUT',
+      headers: {
+        Authorization: this.auth,
+        'Content-Type': 'application/x-sqlite3',
+        'Content-Length': fileSizeInBytes
+      },
+      body: readStream,
+      duplex: 'half'
+    });
+
+    if (!response.ok) {
+      const geoServerResponse = await getGeoServerResponseText(response);
+      throw new GeoServerResponseError(null, geoServerResponse);
+    }
+  }
+
+  /**
+   * Creates a GeoPackage store from a local file and publishes it as layer.
+   * Data will be uploaded to GeoServer's platform.
+   *
+   * @param {String} workspace The WS to create the data store in
+   * @param {String} dataStore The data store name
+   * @param {String} gpkgPath  Local path to GeoPackage file
+   * @param {String} [fileName] Target file name on server
+   */
+  async createGpkgFromFile(workspace, dataStore, gpkgPath, fileName) {
+    const stats = fs.statSync(gpkgPath);
+    const readStream = fs.createReadStream(gpkgPath);
+
+    return this.createGpkgFromStream(workspace, dataStore, readStream, stats.size, fileName);
+  }
 }

--- a/src/datastore.js
+++ b/src/datastore.js
@@ -176,21 +176,20 @@ export default class DatastoreClient {
   }
 
   /**
-   * Creates a GeoTIFF store from a file by path and publishes it as layer.
-   * The GeoTIFF file has to be placed on the server, where your GeoServer
-   * is running.
+   * Creates a GeoTIFF store from a local file and publishes it as layer.
+   * The GeoTIFF file will be uploaded to GeoServer's platform.
    *
    * @param {String} workspace The workspace to create GeoTIFF store in
    * @param {String} coverageStore The name of the new GeoTIFF store
-   * @param {String} layerName The published name of the new layer
-   * @param {String} layerTitle The published title of the new layer
+   * @param {String} layerName Name of the newly created coverage/layer
+   * @param {String} fileName Target file name on server, will appear as layer title in GS
    * @param {String} filePath The path to the GeoTIFF file on the server
    *
    * @throws Error if request fails
    *
    * @returns {String} The successful response text
    */
-  async createGeotiffFromFile(workspace, coverageStore, layerName, layerTitle, filePath) {
+  async createGeotiffFromFile(workspace, coverageStore, layerName, fileName, filePath) {
     const stats = fs.statSync(filePath);
     const fileSizeInBytes = stats.size;
     const readStream = fs.createReadStream(filePath);
@@ -199,21 +198,20 @@ export default class DatastoreClient {
       workspace,
       coverageStore,
       layerName,
-      layerTitle,
+      fileName,
       readStream,
       fileSizeInBytes
     );
   }
 
   /**
-   * Creates a GeoTIFF store from a file by stream and publishes it as layer.
-   * The GeoTIFF file is placed on the server, where your GeoServer
-   * is running.
+   * Creates a GeoTIFF store from a file stream and publishes it as layer.
+   * The GeoTIFF file will be uploaded to GeoServer's platform.
    *
    * @param {String} workspace The workspace to create GeoTIFF store in
    * @param {String} coverageStore The name of the new GeoTIFF store
-   * @param {String} layerName The published name of the new layer
-   * @param {String} layerTitle The published title of the new layer
+   * @param {String} layerName Name of the newly created coverage/layer
+   * @param {String} fileName Target file name on server, will appear as layer title in GS
    * @param {fs.ReadStream} readStream The stream of the GeoTIFF file
    * @param {Number} fileSizeInBytes The number of bytes of the stream
    *
@@ -225,15 +223,13 @@ export default class DatastoreClient {
     workspace,
     coverageStore,
     layerName,
-    layerTitle,
+    fileName,
     readStream,
     fileSizeInBytes
   ) {
-    const lyrTitle = layerTitle || layerName;
-
     let url =
       this.url + 'workspaces/' + workspace + '/coveragestores/' + coverageStore + '/file.geotiff';
-    url += '?filename=' + lyrTitle + '&coverageName=' + layerName;
+    url += '?filename=' + fileName + '&coverageName=' + layerName;
     const response = await fetch(url, {
       credentials: 'include',
       method: 'PUT',

--- a/test/test.js
+++ b/test/test.js
@@ -434,7 +434,7 @@ describe('Layer', () => {
     await grc.layers.deleteFeatureType(workSpace, wfsDataStore, featureLayerName, recursive);
   });
 
-  it('can create Coverage layer', async () => {
+  it('can create Coverage layer directly from GeoTiff file', async () => {
     const geotiff = 'test/sample_data/world.tif';
     await grc.datastores.createGeotiffFromFile(
       workSpace,
@@ -445,9 +445,16 @@ describe('Layer', () => {
     );
   });
 
+  it('can create layer directly from GPKG file', async () => {
+    const storeName = 'gpkg-store';
+    const gpkg = 'test/sample_data/iceland.gpkg';
+    const fileNameOnServer = 'my-super-gpkg-file';
+    await grc.datastores.createGpkgFromFile(workSpace, storeName, gpkg, fileNameOnServer);
+  });
+
   it('can get layers by workspace', async () => {
     const result = await grc.layers.getLayers(workSpace);
-    expect(result.layers.layer.length).to.equal(4);
+    expect(result.layers.layer.length).to.equal(5);
   });
 
   it('works with non-existing workspaces', async () => {


### PR DESCRIPTION
Adds 2 new API functions:

- `createGpkgFromFile`
- `createGpkgFromStream`

within the `DatastoreClient` class. 

Also fixes and harmonizes the API docs of the corresponding  `createGeotiffFromFile` and `createGeotiffFromStream` functions.