### PR TITLE
Add wrappers/aliases for file-based layer publishing in LayerClient

### DIFF
--- a/src/layer.js
+++ b/src/layer.js
@@ -1,6 +1,7 @@
 import fetch from 'node-fetch';
 import { getGeoServerResponseText, GeoServerResponseError } from './util/geoserver.js';
 import AboutClient from './about.js';
+import DatastoreClient from './datastore.js';
 
 /**
  * Client for GeoServer layers
@@ -944,5 +945,103 @@ export default class LayerClient {
       }
     }
     return response.json();
+  }
+
+  /**
+   * Publishes a Coverage layer based on a local GeoTIFF file stream.
+   * Also creates underlying GeoTIFF store from a file stream.
+   * The GeoTIFF file will therefore be uploaded to GeoServer's platform.
+   *
+   * @param {String} workspace The workspace to create GeoTIFF store in
+   * @param {String} coverageStore The name of the new GeoTIFF store
+   * @param {String} layerName Name of the newly created coverage/layer
+   * @param {fs.ReadStream} readStream The stream of the GeoTIFF file
+   * @param {Number} fileSizeInBytes The number of bytes of the stream
+   * @param {String} [fileName] Target file name on server, will appear as layer title in GS
+   *
+   * @throws Error if request fails
+   *
+   * @returns {String} The successful response text
+   */
+  async publishGeotiffFromStream(
+    workspace,
+    coverageStore,
+    layerName,
+    readStream,
+    fileSizeInBytes,
+    fileName
+  ) {
+    const storeClient = new DatastoreClient(this.url, this.auth);
+    return storeClient.createGeotiffFromStream(
+      workspace,
+      coverageStore,
+      layerName,
+      fileName,
+      readStream,
+      fileSizeInBytes
+    );
+  }
+
+  /**
+   * Publishes a Coverage layer based on a local GeoTIFF file.
+   * Also creates underlying GeoTIFF store from a local file.
+   * The GeoTIFF file will therefore be uploaded to GeoServer's platform.
+   *
+   * @param {String} workspace The workspace to create GeoTIFF store in
+   * @param {String} coverageStore The name of the new GeoTIFF store
+   * @param {String} layerName Name of the newly created coverage/layer
+   * @param {String} filePath Local path to the GeoTIFF file
+   * @param {String} [fileName] Target file name on server, will appear as layer title in GS
+   *
+   * @throws Error if request fails
+   *
+   * @returns {String} The successful response text
+   */
+  async publishGeotiffFromFile(workspace, coverageStore, layerName, filePath, fileName) {
+    const storeClient = new DatastoreClient(this.url, this.auth);
+    return storeClient.createGeotiffFromFile(
+      workspace,
+      coverageStore,
+      layerName,
+      fileName,
+      filePath
+    );
+  }
+
+  /**
+   * Publishes a layer based on a local GPKG file stream.
+   * Also creates underlying GeoPackage store from a stream containing a .gpkg file.
+   * Data will therefore be uploaded to GeoServer's platform.
+   *
+   * @param {String} workspace The WS to create the data store in
+   * @param {String} dataStore The data store name
+   * @param {fs.ReadStream} readStream The stream of the GeoPackage file
+   * @param {Number} fileSizeInBytes The number of bytes of the stream
+   * @param {String} [fileName] Target file name on server
+   */
+  async publishGpkgFromStream(workspace, dataStore, readStream, fileSizeInBytes, fileName) {
+    const storeClient = new DatastoreClient(this.url, this.auth);
+    return storeClient.createGpkgFromStream(
+      workspace,
+      dataStore,
+      readStream,
+      fileSizeInBytes,
+      fileName
+    );
+  }
+
+  /**
+   * Publishes a layer based on a local GPKG file.
+   * Also creates underlying GeoPackage store from a local file.
+   * Data will therefore be uploaded to GeoServer's platform.
+   *
+   * @param {String} workspace The WS to create the data store in
+   * @param {String} dataStore The data store name
+   * @param {String} filePath  Local path to GeoPackage file
+   * @param {String} [fileName] Target file name on server
+   */
+  async publishGpkgFromFile(workspace, dataStore, filePath, fileName) {
+    const storeClient = new DatastoreClient(this.url, this.auth);
+    return storeClient.createGpkgFromFile(workspace, dataStore, filePath, fileName);
   }
 }

--- a/test/test.js
+++ b/test/test.js
@@ -1,5 +1,6 @@
 /* global describe:false, it:false, before:false, after:false */
 import { expect } from 'chai';
+import fs from 'fs';
 import { GeoServerRestClient } from '../geoserver-rest-client.js';
 
 const port = process.env.GEOSERVER_PORT || 8080;
@@ -434,14 +435,28 @@ describe('Layer', () => {
     await grc.layers.deleteFeatureType(workSpace, wfsDataStore, featureLayerName, recursive);
   });
 
+  // ---------
+  //  publish directly from files
+  // ---------
+
   it('can create Coverage layer directly from GeoTiff file', async () => {
     const geotiff = 'test/sample_data/world.tif';
-    await grc.datastores.createGeotiffFromFile(
+    await grc.layers.publishGeotiffFromFile(workSpace, rasterStoreName, rasterLayerName, geotiff);
+  });
+
+  it('can create Coverage layer directly from GeoTiff stream', async () => {
+    const geotiff = 'test/sample_data/world.tif';
+    const layerName = 'geotiff-stream';
+    const stats = fs.statSync(geotiff);
+    const fileSizeInBytes = stats.size;
+    const readStream = fs.createReadStream(geotiff);
+
+    await grc.layers.publishGeotiffFromStream(
       workSpace,
       rasterStoreName,
-      rasterLayerName,
-      'My Raster Title',
-      geotiff
+      layerName,
+      readStream,
+      fileSizeInBytes
     );
   });
 
@@ -449,12 +464,24 @@ describe('Layer', () => {
     const storeName = 'gpkg-store';
     const gpkg = 'test/sample_data/iceland.gpkg';
     const fileNameOnServer = 'my-super-gpkg-file';
-    await grc.datastores.createGpkgFromFile(workSpace, storeName, gpkg, fileNameOnServer);
+
+    await grc.layers.publishGpkgFromFile(workSpace, storeName, gpkg, fileNameOnServer);
+  });
+
+  it('can create layer directly from GPKG stream', async () => {
+    const storeName = 'gpkg-store-stream';
+    const gpkg = 'test/sample_data/iceland.gpkg';
+
+    const stats = fs.statSync(gpkg);
+    const fileSizeInBytes = stats.size;
+    const readStream = fs.createReadStream(gpkg);
+
+    await grc.layers.publishGpkgFromStream(workSpace, storeName, readStream, fileSizeInBytes);
   });
 
   it('can get layers by workspace', async () => {
     const result = await grc.layers.getLayers(workSpace);
-    expect(result.layers.layer.length).to.equal(5);
+    expect(result.layers.layer.length).to.equal(7);
   });
 
   it('works with non-existing workspaces', async () => {


### PR DESCRIPTION
This adds wrappers/aliases in `LayerClient` for the functions `createGeotiffFromStream`, `createGeotiffFromFile`, `createGpkgFromStream` and `createGpkgFromFile` in the `DataStoreClient`:

- `grc.layers.publishGeotiffFromStream`  :arrow_right: `grc.datastores.createGeotiffFromStream`
- `grc.layers.publishGeotiffFromFile`  :arrow_right: `grc.datastores.createGeotiffFromFile`  
- `grc.layers.publishGpkgFromStream`  :arrow_right: `grc.datastores.createGpkgFromStream` 
- `grc.layers.publishGpkgFromFile`  :arrow_right: `grc.datastores.createGpkgFromFile`  

Reason is that the functions create/publish layers and putting them in the `LayerClient`matches how a user would naturally look for them, rather than digging into `DataStoreClient`.

**CAUTION**: In `publishGeotiffFromStream` and `publishGeotiffFromFile` the order of the function parameters slightly changed compared to `createGeotiffFromStream` and `createGeotiffFromFile`. Reason is a first backwards-compatible harmonization with `publishGpkgFromStream` /  `publishGpkgFromFile`.