### PR TITLE
Ensure no undefined filename in publishGeotiff* functions

### DIFF
--- a/src/layer.js
+++ b/src/layer.js
@@ -976,7 +976,7 @@ export default class LayerClient {
       workspace,
       coverageStore,
       layerName,
-      fileName,
+      fileName || layerName,
       readStream,
       fileSizeInBytes
     );
@@ -1003,7 +1003,7 @@ export default class LayerClient {
       workspace,
       coverageStore,
       layerName,
-      fileName,
+      fileName || layerName,
       filePath
     );
   }


### PR DESCRIPTION
This is a fixup for #490 and ensures that no `undefined` `filename` is published by `publishGeotiffFromStream` and
`publishGeotiffFromFile` functions in `LayerClient`.